### PR TITLE
[#13] Add basic TaskRunner::PostDelayedTask() implementation

### DIFF
--- a/examples/simple/main.cc
+++ b/examples/simple/main.cc
@@ -72,7 +72,7 @@ void ThreadDelayedExample() {
       FROM_HERE,
       base::BindOnce(
           []([[maybe_unused]] base::AutoSignaller finished_signaller) {
-            LOG(ERROR)
+            LOG(INFO)
                 << "ThreadDelayedExample() delayed (300ms) task executing";
           },
           base::AutoSignaller{&finished_event}),
@@ -80,12 +80,12 @@ void ThreadDelayedExample() {
 
   thread.TaskRunner()->PostTask(
       FROM_HERE, base::BindOnce([]() {
-        LOG(ERROR) << "ThreadDelayedExample() non-delayed task executing";
+        LOG(INFO) << "ThreadDelayedExample() non-delayed task executing";
       }));
 
   thread.TaskRunner()->PostDelayedTask(
       FROM_HERE, base::BindOnce([]() {
-        LOG(ERROR) << "ThreadDelayedExample() delayed (100ms) task executing";
+        LOG(INFO) << "ThreadDelayedExample() delayed (100ms) task executing";
       }),
       base::Milliseconds(100));
 
@@ -139,7 +139,7 @@ int main(int /*argc*/, char* argv[]) {
 
   const auto time_after = base::TimeTicks::Now();
   LOG(INFO) << "Test finished in "
-            << (time_after - time_before).InMicroseconds() << "us";
+            << (time_after - time_before).InMillisecondsF() << "us";
 
   google::ShutdownGoogleLogging();
 

--- a/examples/simple/main.cc
+++ b/examples/simple/main.cc
@@ -62,6 +62,39 @@ void ThreadExample() {
   t1.Stop();
 }
 
+void ThreadDelayedExample() {
+  base::Thread thread{};
+  base::WaitableEvent finished_event{};
+
+  thread.Start();
+
+  thread.TaskRunner()->PostDelayedTask(
+      FROM_HERE,
+      base::BindOnce(
+          []([[maybe_unused]] base::AutoSignaller finished_signaller) {
+            LOG(ERROR)
+                << "ThreadDelayedExample() delayed (300ms) task executing";
+          },
+          base::AutoSignaller{&finished_event}),
+      base::Milliseconds(300));
+
+  thread.TaskRunner()->PostTask(
+      FROM_HERE, base::BindOnce([]() {
+        LOG(ERROR) << "ThreadDelayedExample() non-delayed task executing";
+      }));
+
+  thread.TaskRunner()->PostDelayedTask(
+      FROM_HERE, base::BindOnce([]() {
+        LOG(ERROR) << "ThreadDelayedExample() delayed (100ms) task executing";
+      }),
+      base::Milliseconds(100));
+
+  finished_event.Wait();
+  LOG(INFO) << __FUNCTION__ << "() finished";
+
+  thread.Stop();
+}
+
 void ThreadPoolNonSequencedExample() {
   base::ThreadPool pool{1};
   pool.Start();
@@ -99,6 +132,7 @@ int main(int /*argc*/, char* argv[]) {
   const auto time_before = base::TimeTicks::Now();
 
   ThreadExample();
+  ThreadDelayedExample();
   ThreadPoolNonSequencedExample();
   ThreadPoolSequencedExample();
   ThreadPoolSingleThreadExample();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,10 @@ target_sources(libbase
     base/task_runner.cc
     base/task_runner.h
     base/task_runner_internals.h
+    base/threading/delayed_task_manager.cc
+    base/threading/delayed_task_manager.h
+    base/threading/delayed_task_manager_shared_instance.cc
+    base/threading/delayed_task_manager_shared_instance.h
     base/threading/sequenced_task_runner_handle.cc
     base/threading/sequenced_task_runner_handle.h
     base/threading/task_runner_impl.cc

--- a/src/base/message_loop/message_loop.h
+++ b/src/base/message_loop/message_loop.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "base/callback_forward.h"
+#include "base/message_loop/message_pump.h"
 
 namespace base {
 
@@ -12,7 +13,7 @@ class MessageLoop {
   virtual void RunUntilIdle() = 0;
 
   virtual void Run() = 0;
-  virtual void Stop(OnceClosure last_task) = 0;
+  virtual void Stop(MessagePump::PendingTask last_task) = 0;
 };
 
 }  // namespace base

--- a/src/base/message_loop/message_loop_impl.cc
+++ b/src/base/message_loop/message_loop_impl.cc
@@ -2,6 +2,7 @@
 
 #include "base/bind.h"
 #include "base/sequenced_task_runner_helpers.h"
+#include "base/threading/delayed_task_manager_shared_instance.h"
 #include "base/threading/sequenced_task_runner_handle.h"
 #include "base/threading/task_runner_impl.h"
 
@@ -55,7 +56,8 @@ void MessageLoopImpl::RunTask(MessagePump::PendingTask&& pending_task) {
     const auto scoped_task_runner_handle =
         SequencedTaskRunnerHandle{std::make_shared<SequencedTaskRunnerImpl>(
             std::weak_ptr<MessagePump>(message_pump_),
-            *pending_task.sequence_id)};
+            *pending_task.sequence_id,
+            DelayedTaskManagerSharedInstance::GetOrCreateSharedInstance())};
 
     std::move(pending_task.task).Run();
   } else {

--- a/src/base/message_loop/message_loop_impl.h
+++ b/src/base/message_loop/message_loop_impl.h
@@ -18,11 +18,10 @@ class MessageLoopImpl : public MessageLoop {
   bool RunOnce() override;
   void RunUntilIdle() override;
   void Run() override;
-  void Stop(OnceClosure last_task) override;
+  void Stop(MessagePump::PendingTask last_task) override;
 
  private:
   void RunUntilIdleOrStop();
-  void RunTask(MessagePump::PendingTask&& pending_task);
 
   const MessagePump::ExecutorId executor_id_;
   std::shared_ptr<MessagePump> message_pump_;

--- a/src/base/message_loop/message_pump.h
+++ b/src/base/message_loop/message_pump.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <memory>
 #include <optional>
 
 #include "base/callback.h"
 #include "base/sequence_id.h"
 
 namespace base {
+
+class SequencedTaskRunner;
 
 class MessagePump {
  public:
@@ -17,6 +20,7 @@ class MessagePump {
     OnceClosure task;
     std::optional<SequenceId> sequence_id;
     std::optional<ExecutorId> allowed_executor_id;
+    std::weak_ptr<SequencedTaskRunner> target_task_runner;
   };
 
   virtual ~MessagePump() = default;

--- a/src/base/task_runner.cc
+++ b/src/base/task_runner.cc
@@ -59,6 +59,11 @@ class PostTaskAndReplyHelper {
 
 }  // namespace
 
+bool TaskRunner::PostTask(SourceLocation location, OnceClosure task) {
+  const auto kNoDelay = base::TimeDelta{};
+  return PostDelayedTask(std::move(location), std::move(task), kNoDelay);
+}
+
 bool TaskRunner::PostTaskAndReply(SourceLocation location,
                                   OnceClosure task,
                                   OnceClosure reply) {

--- a/src/base/task_runner.h
+++ b/src/base/task_runner.h
@@ -5,6 +5,7 @@
 #include "base/callback.h"
 #include "base/source_location.h"
 #include "base/task_runner_internals.h"
+#include "base/time/time_delta.h"
 
 namespace base {
 
@@ -12,7 +13,11 @@ class TaskRunner {
  public:
   virtual ~TaskRunner() = default;
 
-  virtual bool PostTask(SourceLocation location, OnceClosure task) = 0;
+  bool PostTask(SourceLocation location, OnceClosure task);
+
+  virtual bool PostDelayedTask(SourceLocation location,
+                               OnceClosure task,
+                               TimeDelta delay) = 0;
 
   bool PostTaskAndReply(SourceLocation location,
                         OnceClosure task,

--- a/src/base/threading/delayed_task_manager.cc
+++ b/src/base/threading/delayed_task_manager.cc
@@ -1,0 +1,103 @@
+#include "base/threading/delayed_task_manager.h"
+
+#include <chrono>
+
+#include "base/logging.h"
+
+namespace base {
+
+bool DelayedTaskManager::DelayedTask::operator<(const DelayedTask& rhs) const {
+  // We're returning bigger value, because we want to sort the tasks from the
+  // one with smaller start_time at the top, while std::priority_queue<T> - by
+  // default - chooses the one with the highest value as top(). This inverses
+  // the ordering.
+  return start_time > rhs.start_time;
+}
+
+DelayedTaskManager::DelayedTaskManager() : stopped_(false) {
+  scheduler_thread_ =
+      std::thread{&DelayedTaskManager::ScheduleTasksUntilStop, this};
+}
+
+DelayedTaskManager::~DelayedTaskManager() {
+  {
+    std::lock_guard<std::mutex> guard{mutex_};
+    stopped_ = true;
+  }
+
+  cond_var_.notify_one();
+  scheduler_thread_.join();
+}
+
+void DelayedTaskManager::QueueDelayedTask(DelayedTask delayed_task) {
+  std::lock_guard<std::mutex> lock{mutex_};
+
+  if (stopped_) {
+    // Skip scheduling new tasks when stopped.
+    return;
+  }
+
+  // If the new task is the first one or it has smaller start time then the
+  // first one then we will need to wake scheduler thread to update how long it
+  // is supposed to wait for the first task (or possibly schedule it right
+  // away).
+  const bool need_to_wake_scheduler =
+      delayed_tasks_.empty() ||
+      (delayed_task.start_time < delayed_tasks_.top().start_time);
+
+  delayed_tasks_.push(std::move(delayed_task));
+
+  if (need_to_wake_scheduler) {
+    cond_var_.notify_one();
+  }
+}
+
+void DelayedTaskManager::ScheduleTasksUntilStop() {
+  std::unique_lock lock(mutex_);
+
+  while (!stopped_) {
+    ScheduleAllReadyTasksLocked();
+    WaitForNextTaskOrStopLocked(lock);
+  }
+}
+
+void DelayedTaskManager::ScheduleAllReadyTasksLocked() {
+  const auto can_run_first_task = [&]() {
+    return !delayed_tasks_.empty() &&
+           delayed_tasks_.top().start_time <= TimeTicks::Now();
+  };
+
+  while (can_run_first_task()) {
+    const auto& first_task = delayed_tasks_.top();
+    if (auto message_pump = first_task.message_pump.lock()) {
+      message_pump->QueuePendingTask(std::move(first_task.pending_task));
+    }
+    delayed_tasks_.pop();
+  }
+}
+
+void DelayedTaskManager::WaitForNextTaskOrStopLocked(
+    std::unique_lock<std::mutex>& lock) {
+  const auto previous_task_count = delayed_tasks_.size();
+  const auto can_resume_from_wait = [&]() {
+    return stopped_ || previous_task_count != delayed_tasks_.size();
+  };
+
+  if (auto next_task_delay = NextTaskRemainingDelayLocked()) {
+    cond_var_.wait_for(
+        lock, std::chrono::microseconds(next_task_delay->InMicroseconds()),
+        can_resume_from_wait);
+  } else {
+    cond_var_.wait(lock, can_resume_from_wait);
+  }
+}
+
+std::optional<TimeDelta> DelayedTaskManager::NextTaskRemainingDelayLocked()
+    const {
+  if (delayed_tasks_.empty()) {
+    return {};
+  }
+  return delayed_tasks_.top().start_time - TimeTicks::Now();
+}
+
+}  // namespace base

--- a/src/base/threading/delayed_task_manager.h
+++ b/src/base/threading/delayed_task_manager.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+#include "base/message_loop/message_pump.h"
+#include "base/time/time_ticks.h"
+
+namespace base {
+
+class DelayedTaskManager {
+ public:
+  struct DelayedTask {
+    bool operator<(const DelayedTask& rhs) const;
+
+    TimeTicks start_time;
+    std::weak_ptr<MessagePump> message_pump;
+    mutable MessagePump::PendingTask pending_task;
+  };
+
+  DelayedTaskManager();
+  ~DelayedTaskManager();
+
+  void QueueDelayedTask(DelayedTask delayed_task);
+
+ private:
+  void ScheduleTasksUntilStop();
+  void ScheduleAllReadyTasksLocked();
+  void WaitForNextTaskOrStopLocked(std::unique_lock<std::mutex>& lock);
+  std::optional<TimeDelta> NextTaskRemainingDelayLocked() const;
+
+  std::thread scheduler_thread_;
+  std::mutex mutex_;
+  std::condition_variable cond_var_;
+
+  // Everything below is locked behind |mutex_|.
+  bool stopped_;
+  std::priority_queue<DelayedTask> delayed_tasks_;
+};
+
+}  // namespace base

--- a/src/base/threading/delayed_task_manager_shared_instance.cc
+++ b/src/base/threading/delayed_task_manager_shared_instance.cc
@@ -1,0 +1,28 @@
+#include "base/threading/delayed_task_manager_shared_instance.h"
+
+#include "base/threading/delayed_task_manager.h"
+
+namespace base {
+
+// static
+std::shared_ptr<DelayedTaskManager>
+DelayedTaskManagerSharedInstance::GetOrCreateSharedInstance() {
+  auto& instance = GetInstance();
+
+  std::lock_guard<std::mutex> guard{instance.mutex_};
+  if (auto x = instance.current_manager_.lock()) {
+    return x;
+  }
+  std::shared_ptr<DelayedTaskManager> new_manager{new DelayedTaskManager()};
+  instance.current_manager_ = new_manager;
+  return new_manager;
+}
+
+// static
+DelayedTaskManagerSharedInstance&
+DelayedTaskManagerSharedInstance::GetInstance() {
+  static DelayedTaskManagerSharedInstance instance;
+  return instance;
+}
+
+}  // namespace base

--- a/src/base/threading/delayed_task_manager_shared_instance.h
+++ b/src/base/threading/delayed_task_manager_shared_instance.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+
+namespace base {
+
+class DelayedTaskManager;
+
+class DelayedTaskManagerSharedInstance {
+ public:
+  static std::shared_ptr<DelayedTaskManager> GetOrCreateSharedInstance();
+
+ private:
+  static DelayedTaskManagerSharedInstance& GetInstance();
+
+  std::mutex mutex_;
+  std::weak_ptr<DelayedTaskManager> current_manager_;
+};
+
+}  // namespace base

--- a/src/base/threading/sequenced_task_runner_handle.cc
+++ b/src/base/threading/sequenced_task_runner_handle.cc
@@ -23,6 +23,7 @@ bool SequencedTaskRunnerHandle::IsSet() {
 SequencedTaskRunnerHandle::SequencedTaskRunnerHandle(
     std::shared_ptr<SequencedTaskRunner> task_runner)
     : task_runner_(std::move(task_runner)) {
+  DCHECK(task_runner_);
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
   DCHECK(!IsSet());
 

--- a/src/base/threading/task_runner_impl.cc
+++ b/src/base/threading/task_runner_impl.cc
@@ -1,6 +1,8 @@
 #include "base/threading/task_runner_impl.h"
 
 #include "base/sequenced_task_runner_helpers.h"
+#include "base/threading/delayed_task_manager.h"
+#include "base/time/time_ticks.h"
 
 namespace base {
 
@@ -8,14 +10,23 @@ namespace {
 bool DoPostTask(
     SourceLocation location,
     OnceClosure task,
+    TimeDelta delay,
+    std::shared_ptr<DelayedTaskManager>& delayed_task_manager,
     const std::weak_ptr<MessagePump>& weak_pump,
     std::optional<SequenceId> sequence_id = {},
     const std::optional<MessagePump::ExecutorId>& executor_id = {}) {
   (void)location;
 
-  if (auto pump = weak_pump.lock()) {
-    return pump->QueuePendingTask(
-        {std::move(task), std::move(sequence_id), executor_id});
+  if (delay.IsZero() || delay.IsNegative()) {
+    if (auto pump = weak_pump.lock()) {
+      return pump->QueuePendingTask(
+          {std::move(task), std::move(sequence_id), executor_id});
+    }
+  } else {
+    delayed_task_manager->QueueDelayedTask(DelayedTaskManager::DelayedTask{
+        (TimeTicks::Now() + delay), weak_pump,
+        MessagePump::PendingTask{std::move(task), std::move(sequence_id),
+                                 executor_id}});
   }
 
   return false;
@@ -26,21 +37,36 @@ bool DoRunsInCurrentSequence(const SequenceId& sequence_id) {
 }
 }  // namespace
 
-TaskRunnerImpl::TaskRunnerImpl(std::weak_ptr<MessagePump> pump)
-    : pump_(std::move(pump)) {}
+TaskRunnerImpl::TaskRunnerImpl(
+    std::weak_ptr<MessagePump> pump,
+    std::shared_ptr<DelayedTaskManager> delayed_task_manager)
+    : pump_(std::move(pump)),
+      delayed_task_manager_(std::move(delayed_task_manager)) {
+  DCHECK(delayed_task_manager_);
+}
 
-bool TaskRunnerImpl::PostTask(SourceLocation location, OnceClosure task) {
-  return DoPostTask(std::move(location), std::move(task), pump_);
+bool TaskRunnerImpl::PostDelayedTask(SourceLocation location,
+                                     OnceClosure task,
+                                     TimeDelta delay) {
+  return DoPostTask(std::move(location), std::move(task), std::move(delay),
+                    delayed_task_manager_, pump_);
 }
 
 SequencedTaskRunnerImpl::SequencedTaskRunnerImpl(
     std::weak_ptr<MessagePump> pump,
-    SequenceId sequence_id)
-    : pump_(std::move(pump)), sequence_id_(std::move(sequence_id)) {}
+    SequenceId sequence_id,
+    std::shared_ptr<DelayedTaskManager> delayed_task_manager)
+    : pump_(std::move(pump)),
+      sequence_id_(std::move(sequence_id)),
+      delayed_task_manager_(std::move(delayed_task_manager)) {
+  DCHECK(delayed_task_manager_);
+}
 
-bool SequencedTaskRunnerImpl::PostTask(SourceLocation location,
-                                       OnceClosure task) {
-  return DoPostTask(std::move(location), std::move(task), pump_, sequence_id_);
+bool SequencedTaskRunnerImpl::PostDelayedTask(SourceLocation location,
+                                              OnceClosure task,
+                                              TimeDelta delay) {
+  return DoPostTask(std::move(location), std::move(task), std::move(delay),
+                    delayed_task_manager_, pump_, sequence_id_);
 }
 
 bool SequencedTaskRunnerImpl::RunsTasksInCurrentSequence() const {
@@ -50,15 +76,20 @@ bool SequencedTaskRunnerImpl::RunsTasksInCurrentSequence() const {
 SingleThreadTaskRunnerImpl::SingleThreadTaskRunnerImpl(
     std::weak_ptr<MessagePump> pump,
     SequenceId sequence_id,
-    MessagePump::ExecutorId executor_id)
+    MessagePump::ExecutorId executor_id,
+    std::shared_ptr<DelayedTaskManager> delayed_task_manager)
     : pump_(std::move(pump)),
       sequence_id_(std::move(sequence_id)),
-      executor_id_(std::move(executor_id)) {}
+      executor_id_(std::move(executor_id)),
+      delayed_task_manager_(std::move(delayed_task_manager)) {
+  DCHECK(delayed_task_manager_);
+}
 
-bool SingleThreadTaskRunnerImpl::PostTask(SourceLocation location,
-                                          OnceClosure task) {
-  return DoPostTask(std::move(location), std::move(task), pump_, sequence_id_,
-                    executor_id_);
+bool SingleThreadTaskRunnerImpl::PostDelayedTask(SourceLocation location,
+                                                 OnceClosure task,
+                                                 TimeDelta delay) {
+  return DoPostTask(std::move(location), std::move(task), std::move(delay),
+                    delayed_task_manager_, pump_, sequence_id_, executor_id_);
 }
 
 bool SingleThreadTaskRunnerImpl::RunsTasksInCurrentSequence() const {

--- a/src/base/threading/task_runner_impl.cc
+++ b/src/base/threading/task_runner_impl.cc
@@ -13,20 +13,23 @@ bool DoPostTask(
     TimeDelta delay,
     std::shared_ptr<DelayedTaskManager>& delayed_task_manager,
     const std::weak_ptr<MessagePump>& weak_pump,
+    std::weak_ptr<SequencedTaskRunner> target_sequenced_task_runner,
     std::optional<SequenceId> sequence_id = {},
     const std::optional<MessagePump::ExecutorId>& executor_id = {}) {
   (void)location;
 
   if (delay.IsZero() || delay.IsNegative()) {
     if (auto pump = weak_pump.lock()) {
-      return pump->QueuePendingTask(
-          {std::move(task), std::move(sequence_id), executor_id});
+      return pump->QueuePendingTask({std::move(task), std::move(sequence_id),
+                                     executor_id,
+                                     std::move(target_sequenced_task_runner)});
     }
   } else {
     delayed_task_manager->QueueDelayedTask(DelayedTaskManager::DelayedTask{
         (TimeTicks::Now() + delay), weak_pump,
         MessagePump::PendingTask{std::move(task), std::move(sequence_id),
-                                 executor_id}});
+                                 executor_id,
+                                 std::move(target_sequenced_task_runner)}});
   }
 
   return false;
@@ -37,6 +40,25 @@ bool DoRunsInCurrentSequence(const SequenceId& sequence_id) {
 }
 }  // namespace
 
+//
+// TaskRunnerImpl
+//
+
+// static
+std::shared_ptr<TaskRunnerImpl> TaskRunnerImpl::Create(
+    std::weak_ptr<MessagePump> pump,
+    std::shared_ptr<DelayedTaskManager> delayed_task_manager) {
+  return std::shared_ptr<TaskRunnerImpl>(
+      new TaskRunnerImpl(std::move(pump), std::move(delayed_task_manager)));
+}
+
+bool TaskRunnerImpl::PostDelayedTask(SourceLocation location,
+                                     OnceClosure task,
+                                     TimeDelta delay) {
+  return DoPostTask(std::move(location), std::move(task), std::move(delay),
+                    delayed_task_manager_, pump_, {});
+}
+
 TaskRunnerImpl::TaskRunnerImpl(
     std::weak_ptr<MessagePump> pump,
     std::shared_ptr<DelayedTaskManager> delayed_task_manager)
@@ -45,11 +67,29 @@ TaskRunnerImpl::TaskRunnerImpl(
   DCHECK(delayed_task_manager_);
 }
 
-bool TaskRunnerImpl::PostDelayedTask(SourceLocation location,
-                                     OnceClosure task,
-                                     TimeDelta delay) {
+//
+// SequencedTaskRunnerImpl
+//
+
+// static
+std::shared_ptr<SequencedTaskRunnerImpl> SequencedTaskRunnerImpl::Create(
+    std::weak_ptr<MessagePump> pump,
+    SequenceId sequence_id,
+    std::shared_ptr<DelayedTaskManager> delayed_task_manager) {
+  return std::shared_ptr<SequencedTaskRunnerImpl>(new SequencedTaskRunnerImpl(
+      std::move(pump), sequence_id, std::move(delayed_task_manager)));
+}
+
+bool SequencedTaskRunnerImpl::PostDelayedTask(SourceLocation location,
+                                              OnceClosure task,
+                                              TimeDelta delay) {
   return DoPostTask(std::move(location), std::move(task), std::move(delay),
-                    delayed_task_manager_, pump_);
+                    delayed_task_manager_, pump_, weak_from_this(),
+                    sequence_id_);
+}
+
+bool SequencedTaskRunnerImpl::RunsTasksInCurrentSequence() const {
+  return DoRunsInCurrentSequence(sequence_id_);
 }
 
 SequencedTaskRunnerImpl::SequencedTaskRunnerImpl(
@@ -62,14 +102,30 @@ SequencedTaskRunnerImpl::SequencedTaskRunnerImpl(
   DCHECK(delayed_task_manager_);
 }
 
-bool SequencedTaskRunnerImpl::PostDelayedTask(SourceLocation location,
-                                              OnceClosure task,
-                                              TimeDelta delay) {
-  return DoPostTask(std::move(location), std::move(task), std::move(delay),
-                    delayed_task_manager_, pump_, sequence_id_);
+//
+// SingleThreadTaskRunnerImpl
+//
+
+// static
+std::shared_ptr<SingleThreadTaskRunnerImpl> SingleThreadTaskRunnerImpl::Create(
+    std::weak_ptr<MessagePump> pump,
+    SequenceId sequence_id,
+    MessagePump::ExecutorId executor_id,
+    std::shared_ptr<DelayedTaskManager> delayed_task_manager) {
+  return std::shared_ptr<SingleThreadTaskRunnerImpl>(
+      new SingleThreadTaskRunnerImpl(std::move(pump), sequence_id, executor_id,
+                                     std::move(delayed_task_manager)));
 }
 
-bool SequencedTaskRunnerImpl::RunsTasksInCurrentSequence() const {
+bool SingleThreadTaskRunnerImpl::PostDelayedTask(SourceLocation location,
+                                                 OnceClosure task,
+                                                 TimeDelta delay) {
+  return DoPostTask(std::move(location), std::move(task), std::move(delay),
+                    delayed_task_manager_, pump_, weak_from_this(),
+                    sequence_id_, executor_id_);
+}
+
+bool SingleThreadTaskRunnerImpl::RunsTasksInCurrentSequence() const {
   return DoRunsInCurrentSequence(sequence_id_);
 }
 
@@ -83,17 +139,6 @@ SingleThreadTaskRunnerImpl::SingleThreadTaskRunnerImpl(
       executor_id_(std::move(executor_id)),
       delayed_task_manager_(std::move(delayed_task_manager)) {
   DCHECK(delayed_task_manager_);
-}
-
-bool SingleThreadTaskRunnerImpl::PostDelayedTask(SourceLocation location,
-                                                 OnceClosure task,
-                                                 TimeDelta delay) {
-  return DoPostTask(std::move(location), std::move(task), std::move(delay),
-                    delayed_task_manager_, pump_, sequence_id_, executor_id_);
-}
-
-bool SingleThreadTaskRunnerImpl::RunsTasksInCurrentSequence() const {
-  return DoRunsInCurrentSequence(sequence_id_);
 }
 
 }  // namespace base

--- a/src/base/threading/task_runner_impl.h
+++ b/src/base/threading/task_runner_impl.h
@@ -14,7 +14,7 @@ class DelayedTaskManager;
 
 class TaskRunnerImpl : public TaskRunner {
  public:
-  explicit TaskRunnerImpl(
+  static std::shared_ptr<TaskRunnerImpl> Create(
       std::weak_ptr<MessagePump> pump,
       std::shared_ptr<DelayedTaskManager> delayed_task_manager);
 
@@ -24,13 +24,19 @@ class TaskRunnerImpl : public TaskRunner {
                        TimeDelta delay) override;
 
  private:
+  explicit TaskRunnerImpl(
+      std::weak_ptr<MessagePump> pump,
+      std::shared_ptr<DelayedTaskManager> delayed_task_manager);
+
   std::weak_ptr<MessagePump> pump_;
   std::shared_ptr<DelayedTaskManager> delayed_task_manager_;
 };
 
-class SequencedTaskRunnerImpl : public SequencedTaskRunner {
+class SequencedTaskRunnerImpl
+    : public SequencedTaskRunner,
+      public std::enable_shared_from_this<SequencedTaskRunnerImpl> {
  public:
-  SequencedTaskRunnerImpl(
+  static std::shared_ptr<SequencedTaskRunnerImpl> Create(
       std::weak_ptr<MessagePump> pump,
       SequenceId sequence_id,
       std::shared_ptr<DelayedTaskManager> delayed_task_manager);
@@ -42,14 +48,21 @@ class SequencedTaskRunnerImpl : public SequencedTaskRunner {
   bool RunsTasksInCurrentSequence() const override;
 
  private:
+  SequencedTaskRunnerImpl(
+      std::weak_ptr<MessagePump> pump,
+      SequenceId sequence_id,
+      std::shared_ptr<DelayedTaskManager> delayed_task_manager);
+
   std::weak_ptr<MessagePump> pump_;
   SequenceId sequence_id_;
   std::shared_ptr<DelayedTaskManager> delayed_task_manager_;
 };
 
-class SingleThreadTaskRunnerImpl : public SingleThreadTaskRunner {
+class SingleThreadTaskRunnerImpl
+    : public SingleThreadTaskRunner,
+      public std::enable_shared_from_this<SingleThreadTaskRunnerImpl> {
  public:
-  SingleThreadTaskRunnerImpl(
+  static std::shared_ptr<SingleThreadTaskRunnerImpl> Create(
       std::weak_ptr<MessagePump> pump,
       SequenceId sequence_id,
       MessagePump::ExecutorId executor_id,
@@ -62,6 +75,12 @@ class SingleThreadTaskRunnerImpl : public SingleThreadTaskRunner {
   bool RunsTasksInCurrentSequence() const override;
 
  private:
+  SingleThreadTaskRunnerImpl(
+      std::weak_ptr<MessagePump> pump,
+      SequenceId sequence_id,
+      MessagePump::ExecutorId executor_id,
+      std::shared_ptr<DelayedTaskManager> delayed_task_manager);
+
   std::weak_ptr<MessagePump> pump_;
   SequenceId sequence_id_;
   MessagePump::ExecutorId executor_id_;

--- a/src/base/threading/task_runner_impl.h
+++ b/src/base/threading/task_runner_impl.h
@@ -10,45 +10,62 @@
 
 namespace base {
 
+class DelayedTaskManager;
+
 class TaskRunnerImpl : public TaskRunner {
  public:
-  explicit TaskRunnerImpl(std::weak_ptr<MessagePump> pump);
+  explicit TaskRunnerImpl(
+      std::weak_ptr<MessagePump> pump,
+      std::shared_ptr<DelayedTaskManager> delayed_task_manager);
 
   // TaskRunner
-  bool PostTask(SourceLocation location, OnceClosure task) override;
+  bool PostDelayedTask(SourceLocation location,
+                       OnceClosure task,
+                       TimeDelta delay) override;
 
  private:
   std::weak_ptr<MessagePump> pump_;
+  std::shared_ptr<DelayedTaskManager> delayed_task_manager_;
 };
 
 class SequencedTaskRunnerImpl : public SequencedTaskRunner {
  public:
-  SequencedTaskRunnerImpl(std::weak_ptr<MessagePump> pump,
-                          SequenceId sequence_id);
+  SequencedTaskRunnerImpl(
+      std::weak_ptr<MessagePump> pump,
+      SequenceId sequence_id,
+      std::shared_ptr<DelayedTaskManager> delayed_task_manager);
 
   // SequencedTaskRunner
-  bool PostTask(SourceLocation location, OnceClosure task) override;
+  bool PostDelayedTask(SourceLocation location,
+                       OnceClosure task,
+                       TimeDelta delay) override;
   bool RunsTasksInCurrentSequence() const override;
 
  private:
   std::weak_ptr<MessagePump> pump_;
   SequenceId sequence_id_;
+  std::shared_ptr<DelayedTaskManager> delayed_task_manager_;
 };
 
 class SingleThreadTaskRunnerImpl : public SingleThreadTaskRunner {
  public:
-  SingleThreadTaskRunnerImpl(std::weak_ptr<MessagePump> pump,
-                             SequenceId sequence_id,
-                             MessagePump::ExecutorId executor_id);
+  SingleThreadTaskRunnerImpl(
+      std::weak_ptr<MessagePump> pump,
+      SequenceId sequence_id,
+      MessagePump::ExecutorId executor_id,
+      std::shared_ptr<DelayedTaskManager> delayed_task_manager);
 
   // SingleThreadTaskRunner
-  bool PostTask(SourceLocation location, OnceClosure task) override;
+  bool PostDelayedTask(SourceLocation location,
+                       OnceClosure task,
+                       TimeDelta delay) override;
   bool RunsTasksInCurrentSequence() const override;
 
  private:
   std::weak_ptr<MessagePump> pump_;
   SequenceId sequence_id_;
   MessagePump::ExecutorId executor_id_;
+  std::shared_ptr<DelayedTaskManager> delayed_task_manager_;
 };
 
 }  // namespace base

--- a/src/base/threading/thread.cc
+++ b/src/base/threading/thread.cc
@@ -6,6 +6,7 @@
 #include "base/message_loop/message_pump_impl.h"
 #include "base/sequenced_task_runner_helpers.h"
 #include "base/synchronization/waitable_event.h"
+#include "base/threading/delayed_task_manager_shared_instance.h"
 #include "base/threading/task_runner_impl.h"
 
 namespace base {
@@ -35,7 +36,8 @@ void Thread::Start() {
   std::weak_ptr<MessagePump> weak_message_pump = message_pump;
   task_runner_ = std::make_unique<SingleThreadTaskRunnerImpl>(
       weak_message_pump, detail::SequenceIdGenerator::GetNextSequenceId(),
-      executor_id);
+      executor_id,
+      DelayedTaskManagerSharedInstance::GetOrCreateSharedInstance());
 }
 
 void Thread::Stop() {

--- a/src/base/threading/thread.h
+++ b/src/base/threading/thread.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <thread>
 
 #include "base/callback_forward.h"
 #include "base/message_loop/message_loop.h"
+#include "base/sequence_id.h"
 #include "base/single_thread_task_runner.h"
 #include "base/source_location.h"
 
@@ -27,6 +29,7 @@ class Thread {
  private:
   std::unique_ptr<MessageLoop> message_loop_;
   std::unique_ptr<std::thread> thread_;
+  std::optional<base::SequenceId> sequence_id_;
   std::shared_ptr<SingleThreadTaskRunner> task_runner_;
 };
 

--- a/src/base/threading/thread_pool.cc
+++ b/src/base/threading/thread_pool.cc
@@ -40,14 +40,14 @@ void ThreadPool::Start() {
   }
 
   std::weak_ptr<MessagePump> weak_message_pump = message_pump;
-  task_runner_ = std::make_shared<TaskRunnerImpl>(
+  task_runner_ = TaskRunnerImpl::Create(
       std::move(weak_message_pump),
       DelayedTaskManagerSharedInstance::GetOrCreateSharedInstance());
 }
 
 void ThreadPool::Stop() {
   for (auto& thread : threads_) {
-    thread.message_loop->Stop(base::OnceClosure{});
+    thread.message_loop->Stop({});
     thread.thread->join();
   }
   threads_.clear();
@@ -60,7 +60,7 @@ std::shared_ptr<TaskRunner> ThreadPool::GetTaskRunner() const {
 }
 
 std::shared_ptr<SequencedTaskRunner> ThreadPool::CreateSequencedTaskRunner() {
-  return std::make_shared<SequencedTaskRunnerImpl>(
+  return SequencedTaskRunnerImpl::Create(
       pump_, detail::SequenceIdGenerator::GetNextSequenceId(),
       DelayedTaskManagerSharedInstance::GetOrCreateSharedInstance());
 }
@@ -72,7 +72,7 @@ ThreadPool::CreateSingleThreadTaskRunner() {
   const MessagePump::ExecutorId allowed_executor_id =
       executor_id_distribution(random_generator_);
 
-  return std::make_shared<SingleThreadTaskRunnerImpl>(
+  return SingleThreadTaskRunnerImpl::Create(
       pump_, detail::SequenceIdGenerator::GetNextSequenceId(),
       allowed_executor_id,
       DelayedTaskManagerSharedInstance::GetOrCreateSharedInstance());

--- a/src/base/threading/thread_pool.cc
+++ b/src/base/threading/thread_pool.cc
@@ -7,6 +7,7 @@
 #include "base/message_loop/message_loop_impl.h"
 #include "base/message_loop/message_pump_impl.h"
 #include "base/sequenced_task_runner_helpers.h"
+#include "base/threading/delayed_task_manager_shared_instance.h"
 #include "base/threading/task_runner_impl.h"
 
 namespace base {
@@ -39,7 +40,9 @@ void ThreadPool::Start() {
   }
 
   std::weak_ptr<MessagePump> weak_message_pump = message_pump;
-  task_runner_ = std::make_shared<TaskRunnerImpl>(std::move(weak_message_pump));
+  task_runner_ = std::make_shared<TaskRunnerImpl>(
+      std::move(weak_message_pump),
+      DelayedTaskManagerSharedInstance::GetOrCreateSharedInstance());
 }
 
 void ThreadPool::Stop() {
@@ -58,7 +61,8 @@ std::shared_ptr<TaskRunner> ThreadPool::GetTaskRunner() const {
 
 std::shared_ptr<SequencedTaskRunner> ThreadPool::CreateSequencedTaskRunner() {
   return std::make_shared<SequencedTaskRunnerImpl>(
-      pump_, detail::SequenceIdGenerator::GetNextSequenceId());
+      pump_, detail::SequenceIdGenerator::GetNextSequenceId(),
+      DelayedTaskManagerSharedInstance::GetOrCreateSharedInstance());
 }
 
 std::shared_ptr<SingleThreadTaskRunner>
@@ -70,7 +74,8 @@ ThreadPool::CreateSingleThreadTaskRunner() {
 
   return std::make_shared<SingleThreadTaskRunnerImpl>(
       pump_, detail::SequenceIdGenerator::GetNextSequenceId(),
-      allowed_executor_id);
+      allowed_executor_id,
+      DelayedTaskManagerSharedInstance::GetOrCreateSharedInstance());
 }
 
 }  // namespace base

--- a/tests/unit/base/message_loop/message_pump_impl_unittests.cc
+++ b/tests/unit/base/message_loop/message_pump_impl_unittests.cc
@@ -18,13 +18,19 @@ const size_t kExecutorCount = kHighestExecutorId + 1;
 base::MessagePump::PendingTask CreateExecutorTask(
     base::OnceClosure task,
     std::optional<base::MessagePump::ExecutorId> executor_id) {
-  return {std::move(task), {}, std::move(executor_id)};
+  return {std::move(task),
+          {},
+          std::move(executor_id),
+          std::weak_ptr<base::SequencedTaskRunner>{}};
 }
 
 base::MessagePump::PendingTask CreateSequenceTask(
     base::OnceClosure task,
     std::optional<base::SequenceId> sequence_id) {
-  return {std::move(task), std::move(sequence_id), {}};
+  return {std::move(task),
+          std::move(sequence_id),
+          {},
+          std::weak_ptr<base::SequencedTaskRunner>{}};
 }
 
 base::MessagePump::PendingTask CreateTask(base::OnceClosure task) {

--- a/tests/unit/mock/base/mock_sequenced_task_runner.h
+++ b/tests/unit/mock/base/mock_sequenced_task_runner.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "base/sequenced_task_runner.h"
+
+#include "gmock/gmock.h"
+
+class MockSequencedTaskRunner : public base::SequencedTaskRunner {
+ public:
+  // SequencedTaskRunner
+  MOCK_METHOD(bool,
+              PostDelayedTask,
+              (base::SourceLocation, base::OnceClosure, base::TimeDelta),
+              (override));
+  MOCK_METHOD(bool, RunsTasksInCurrentSequence, (), (const override));
+};


### PR DESCRIPTION
This commit adds basic `TaskRunner::PostDelayedTask()` implementation.
This is implemented by creating a special `DelayedTaskManager` which
receives all post-tasked-with-delay tasks and adds them to a queue
of tasks from which it takes them out and push to the actual
MessagePump once they are ready for processing (sufficient amount of
time has passed). DelayedTaskManager has separate raw thread that
sleeps while waiting for the first task to be ready and then goes
back to sleep after posting/queueing all ready tasks. Instance of
DelayedTaskManager is shared to avoid spawning too many separate
threads just for delaying tasks. All work executed on that thread
is intended to be small anyway as not to block it too much. It
is also not expected to queue too many delayed tasks at the same
time.