### PR TITLE
Avoid duplicate GitHub Actions jobs on pull-request pushes

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,7 +2,12 @@ name: MacOS
 
 on:
   push:
+    branches:
+      - develop
+      - master
+      - release/*
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,7 +2,12 @@ name: Ubuntu
 
 on:
   push:
+    branches:
+      - develop
+      - master
+      - release/*
   pull_request:
+  workflow_dispatch:
 
 jobs:
   clang-format-check:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,12 @@ name: Windows
 
 on:
   push:
+    branches:
+      - develop
+      - master
+      - release/*
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This commit changes GitHub Actions scripts to avoid running
all jobs twice when pushing a change on non-main branch and also
creating a pull-request for it.