### PR TITLE
[#9] Implement simple tracing framework (trace events)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -97,6 +97,7 @@ Checks: ' -*,
   readability-uniqueptr-delete-release,
 
   -modernize-concat-nested-namespaces,
+  -modernize-raw-string-literal,
   -modernize-use-default-member-init,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type'

--- a/CMakeModules/SetupCompileFlags.cmake
+++ b/CMakeModules/SetupCompileFlags.cmake
@@ -11,12 +11,21 @@ function(SETUP_COMPILE_FLAGS)
 
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       # -Wold-style-cast
-      set(WARNINGS "-Wall;-Wextra;-Wpedantic;-Werror;-Wunreachable-code")
+      set(WARNINGS "-Wall;-Wextra;-Werror;-Wunreachable-code")
 
       if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        set(WARNINGS "${WARNINGS};-Wshadow;-Wno-gnu-zero-variadic-macro-arguments")
+        set(WARNINGS "${WARNINGS};-Wpedantic;-Wshadow;-Wno-gnu-zero-variadic-macro-arguments")
       else()
         set(WARNINGS "${WARNINGS};-Wshadow=local")
+
+        # GCC 7.x and older doesn't handle variadic macros that well, so enable
+        # pedanting warnings only on newer versions to avoid the:
+        # > ISO C++11 requires at least one argument for the "..." in a variadic
+        # > macro
+        # error
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0)
+          set(WARNINGS "${WARNINGS};-Wpedantic")
+        endif()
       endif()
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
       set(WARNINGS "/W4;/WX;/EHsc;/permissive-")

--- a/CMakeModules/SetupCompileFlags.cmake
+++ b/CMakeModules/SetupCompileFlags.cmake
@@ -14,7 +14,7 @@ function(SETUP_COMPILE_FLAGS)
       set(WARNINGS "-Wall;-Wextra;-Wpedantic;-Werror;-Wunreachable-code")
 
       if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        set(WARNINGS "${WARNINGS};-Wshadow")
+        set(WARNINGS "${WARNINGS};-Wshadow;-Wno-gnu-zero-variadic-macro-arguments")
       else()
         set(WARNINGS "${WARNINGS};-Wshadow=local")
       endif()

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(simple "")
 
 target_compile_options(simple PRIVATE ${LIBBASE_COMPILE_FLAGS})
-set_target_properties(simple PROPERTIES CXX_EXTENSIONS OFF)
 target_link_libraries(simple PRIVATE libbase)
 
 target_sources(simple

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ target_compile_features(libbase PUBLIC cxx_std_17)
 target_compile_options(libbase PRIVATE ${LIBBASE_COMPILE_FLAGS})
 target_compile_definitions(libbase PUBLIC ${LIBBASE_DEFINES})
 set_target_properties(libbase PROPERTIES
-  CXX_EXTENSIONS OFF
+  CXX_EXTENSIONS ON
   ${LIBBASE_OPT_CLANG_TIDY_PROPERTIES})
 
 target_include_directories(libbase PUBLIC ${libbase_SOURCE_DIR}/src/)
@@ -76,6 +76,21 @@ target_sources(libbase
     base/time/time_ticks.h
     base/timer/elapsed_timer.cc
     base/timer/elapsed_timer.h
+    base/trace_event/trace_argument_packer.h
+    base/trace_event/trace_async.h
+    base/trace_event/trace_complete.h
+    base/trace_event/trace_counter.h
+    base/trace_event/trace_event.h
+    base/trace_event/trace_event_register.h
+    base/trace_event/trace_events.cc
+    base/trace_event/trace_events.h
+    base/trace_event/trace_flow.h
+    base/trace_event/trace_flush.h
+    base/trace_event/trace_json_writer.h
+    base/trace_event/trace_metadata.h
+    base/trace_event/trace_platform.cc
+    base/trace_event/trace_platform.h
+    base/trace_event/trace_signal.h
     base/type_traits.h
     base/vlog_is_on.h
 )

--- a/src/base/trace_event/trace_argument_packer.h
+++ b/src/base/trace_event/trace_argument_packer.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace base {
+namespace detail {
+
+class ArgumentPacker {
+ public:
+  using StringArguments = std::vector<std::pair<std::string, std::string>>;
+  using IntegerArguments = std::vector<std::pair<std::string, uint64_t>>;
+
+  template <typename... Ts>
+  static StringArguments PackStringArguments(Ts&&... args) {
+    static_assert(
+        sizeof...(args) % 2 == 0,
+        "PackStringArguments: arguments must be provided in key-value pairs");
+    StringArguments result;
+
+    result.reserve(sizeof...(args) / 2);
+    AppendArguments(result, std::forward<Ts>(args)...);
+
+    return result;
+  }
+
+  template <typename... Ts>
+  static IntegerArguments PackIntegerArguments(Ts&&... args) {
+    static_assert(
+        sizeof...(args) % 2 == 0,
+        "PackIntegerArguments: arguments must be provided in key-value pairs!");
+    IntegerArguments result;
+
+    result.reserve(sizeof...(args) / 2);
+    AppendArguments(result, std::forward<Ts>(args)...);
+
+    return result;
+  }
+
+ private:
+  template <typename C>
+  static void AppendArguments(C&) {}
+
+  template <typename C, typename K, typename V, typename... Ts>
+  static void AppendArguments(C& container, K&& key, V&& value, Ts&&... rest) {
+    container.emplace_back(std::piecewise_construct, std::forward_as_tuple(key),
+                           std::forward_as_tuple(value));
+    AppendArguments(container, std::forward<Ts>(rest)...);
+  }
+};
+
+}  // namespace detail
+}  // namespace base
+
+#endif

--- a/src/base/trace_event/trace_async.h
+++ b/src/base/trace_event/trace_async.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include "base/trace_event/trace_event_register.h"
+
+#define TRACE_EVENT_ASYNC_BEGIN(categories, name, id, ...)                     \
+  ::base::detail::EventRegister::RegisterAsyncEvent(categories, name, id, 'b', \
+                                                    ##__VA_ARGS__)
+
+#define TRACE_EVENT_ASYNC_STEP(categories, name, id, ...)                      \
+  ::base::detail::EventRegister::RegisterAsyncEvent(categories, name, id, 'n', \
+                                                    ##__VA_ARGS__)
+
+#define TRACE_EVENT_END(categories, name, id, ...)                             \
+  ::base::detail::EventRegister::RegisterAsyncEvent(categories, name, id, 'e', \
+                                                    ##__VA_ARGS__)
+
+#else
+
+#define TRACE_EVENT_ASYNC_BEGIN(categories, name, id, ...)
+#define TRACE_EVENT_ASYNC_STEP(categories, name, id, ...)
+#define TRACE_EVENT_ASYNC_END(categories, name, id, ...)
+
+#endif

--- a/src/base/trace_event/trace_complete.h
+++ b/src/base/trace_event/trace_complete.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include "base/trace_event/trace_event_register.h"
+
+#define TRACE_EVENT_COMPLETE(categories, name, duration, ...) \
+  ::base::detail::EventRegister::RegisterCompleteEvent(       \
+      categories, name, duration, ##__VA_ARGS__)
+
+#else
+
+#define TRACE_EVENT_COMPLETE(categories, name, duration, ...)
+
+#endif

--- a/src/base/trace_event/trace_counter.h
+++ b/src/base/trace_event/trace_counter.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include "base/trace_event/trace_event_register.h"
+
+#define TRACE_COUNTER(categories, name, arg1_key, arg1_value, ...)           \
+  ::base::detail::EventRegister::RegisterCounter(categories, name, arg1_key, \
+                                                 arg1_value, ##__VA_ARGS__)
+
+#define TRACE_COUNTER_ID(categories, name, id, arg1_key, arg1_value, ...) \
+  ::base::detail::EventRegister::RegisterCounterId(                       \
+      categories, name, id, arg1_key, arg1_value, ##__VA_ARGS__)
+
+#else
+
+#define TRACE_COUNTER(categories, name, arg1_key, arg1_value, ...)
+#define TRACE_COUNTER_ID(categories, name, id, arg1_key, arg1_value, ...)
+
+#endif

--- a/src/base/trace_event/trace_event.h
+++ b/src/base/trace_event/trace_event.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include <algorithm>
+#include <string>
+
+#include "base/trace_event/trace_argument_packer.h"
+#include "base/trace_event/trace_event_register.h"
+
+namespace base {
+namespace detail {
+
+class ScopedTraceEvent {
+ public:
+  template <typename... Args>
+  ScopedTraceEvent(std::string categories, std::string name, Args&&... args)
+      : categories_(std::move(categories)), name_(std::move(name)) {
+    EventRegister::RegisterEvent(categories_, name_, 'B',
+                                 std::forward<Args>(args)...);
+  }
+
+  ~ScopedTraceEvent() {
+    EventRegister::RegisterEvent(std::move(categories_), std::move(name_), 'E');
+  }
+
+ private:
+  std::string categories_;
+  std::string name_;
+};
+
+}  // namespace detail
+}  // namespace base
+
+#define TRACE_VAR_NAME_CONCAT_IMPL(a, b) a##b
+#define TRACE_VAR_NAME_CONCAT(a, b) TRACE_VAR_NAME_CONCAT_IMPL(a, b)
+
+#define TRACE_EVENT(categories, name, ...)                \
+  ::base::detail::ScopedTraceEvent TRACE_VAR_NAME_CONCAT( \
+      libbase_scoped_trace_event_, __COUNTER__) {         \
+    categories, name, ##__VA_ARGS__                       \
+  }
+
+#define TRACE_EVENT_BEGIN(categories, name, ...)                      \
+  ::base::detail::EventRegister::RegisterEvent(categories, name, 'B', \
+                                               ##__VA_ARGS__)
+
+#define TRACE_EVENT_END(categories, name, ...)                        \
+  ::base::detail::EventRegister::RegisterEvent(categories, name, 'E', \
+                                               ##__VA_ARGS__)
+
+#else
+
+#define TRACE_EVENT(categories, name, ...)
+#define TRACE_EVENT_BEGIN(categories, name, ...)
+#define TRACE_EVENT_END(categories, name, ...)
+
+#endif

--- a/src/base/trace_event/trace_event_register.h
+++ b/src/base/trace_event/trace_event_register.h
@@ -1,0 +1,185 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include <fstream>
+#include <list>
+#include <mutex>
+#include <string>
+
+#include "base/time/time.h"
+#include "base/trace_event/trace_events.h"
+#include "base/trace_event/trace_json_writer.h"
+#include "base/trace_event/trace_platform.h"
+
+namespace base {
+namespace detail {
+
+class EventRegister {
+ public:
+  template <typename... Args>
+  static void RegisterEvent(std::string categories,
+                            std::string name,
+                            char phase,
+                            Args&&... args) {
+    const char* const kEmptyId = "";
+    GetInstance().PushGenericEvent(
+        std::move(categories), std::move(name), kEmptyId, phase,
+        ArgumentPacker::PackStringArguments(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static void RegisterAsyncEvent(std::string categories,
+                                 std::string name,
+                                 void* id,
+                                 char phase,
+                                 Args&&... args) {
+    GetInstance().PushGenericEvent(
+        std::move(categories), std::move(name),
+        std::to_string(reinterpret_cast<uintptr_t>(id)), phase,
+        ArgumentPacker::PackStringArguments(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static void RegisterCompleteEvent(std::string categories,
+                                    std::string name,
+                                    uint64_t duration,
+                                    Args&&... args) {
+    GetInstance().PushCompleteEvent(
+        std::move(categories), std::move(name), duration,
+        ArgumentPacker::PackStringArguments(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static void RegisterCounter(std::string categories,
+                              std::string name,
+                              Args&&... args) {
+    GetInstance().PushCounter(
+        std::move(categories), std::move(name),
+        ArgumentPacker::PackStringArguments(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static void RegisterCounterId(std::string categories,
+                                std::string name,
+                                void* id,
+                                Args&&... args) {
+    GetInstance().PushCounterId(
+        std::move(categories), std::move(name),
+        std::to_string(reinterpret_cast<uintptr_t>(id)),
+        ArgumentPacker::PackStringArguments(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static void RegisterInstantEvent(std::string categories,
+                                   std::string name,
+                                   char scope,
+                                   Args&&... args) {
+    GetInstance().PushInstantEvent(
+        std::move(categories), std::move(name), std::move(scope),
+        ArgumentPacker::PackStringArguments(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static void FlushEventsToFile(std::string file) {
+    std::ofstream file_stream{file, std::ofstream::out};
+    GetInstance().FlushAllEvents(file_stream);
+  }
+
+  template <typename... Args>
+  static void FlushEventsToStream(std::ostream& stream) {
+    GetInstance().FlushAllEvents(stream);
+  }
+
+ private:
+  static EventRegister& GetInstance() {
+    static EventRegister instance;
+    return instance;
+  }
+
+  uint64_t GetTs() {
+    static const auto origin = base::Time::Now();
+    return (base::Time::Now() - origin).InMicroseconds();
+  }
+
+  uint64_t GetPid() { return TracePlatform::GetPid(); }
+  uint64_t GetTid() { return TracePlatform::GetTid(); }
+
+  void PushGenericEvent(std::string categories,
+                        std::string name,
+                        std::string id,
+                        char phase,
+                        TraceEvent::Arguments args) {
+    std::lock_guard<std::mutex> guard{mutex_};
+    events_.push_back({std::move(name), std::move(categories), std::move(id),
+                       phase, GetTs(), GetPid(), GetTid(), args});
+  }
+
+  void PushCompleteEvent(std::string categories,
+                         std::string name,
+                         uint64_t duration,
+                         TraceCompleteEvent::Arguments args) {
+    const auto now = GetTs();
+    if (now < duration) {
+      return;
+    }
+    const auto ts = now - duration;
+
+    std::lock_guard<std::mutex> guard{mutex_};
+    complete_events_.push_back({std::move(name), std::move(categories), ts,
+                                duration, GetPid(), GetTid(), std::move(args)});
+  }
+
+  void PushCounter(std::string categories,
+                   std::string name,
+                   TraceCounter::Arguments args) {
+    std::lock_guard<std::mutex> guard{mutex_};
+    counter_events_.push_back({std::move(name), std::move(categories), GetTs(),
+                               GetPid(), std::move(args)});
+  }
+
+  void PushCounterId(std::string categories,
+                     std::string name,
+                     std::string id,
+                     TraceCounterId::Arguments args) {
+    std::lock_guard<std::mutex> guard{mutex_};
+    counter_id_events_.push_back({std::move(name), std::move(categories),
+                                  std::move(id), GetTs(), GetPid(),
+                                  std::move(args)});
+  }
+
+  void PushInstantEvent(std::string categories,
+                        std::string name,
+                        char scope,
+                        TraceInstantEvent::Arguments args) {
+    std::lock_guard<std::mutex> guard{mutex_};
+    instant_events_.push_back({std::move(name), std::move(categories),
+                               std::move(scope), GetTs(), GetPid(), GetTid(),
+                               std::move(args)});
+  }
+
+  void FlushAllEvents(std::ostream& stream) {
+    std::lock_guard<std::mutex> guard{mutex_};
+
+    JsonWriter::WriteAll(stream, events_, complete_events_, counter_events_,
+                         counter_id_events_, instant_events_);
+
+    events_ = std::list<TraceEvent>{};
+    complete_events_ = std::list<TraceCompleteEvent>{};
+    counter_events_ = std::list<TraceCounter>{};
+    counter_id_events_ = std::list<TraceCounterId>{};
+    instant_events_ = std::list<TraceInstantEvent>{};
+  }
+
+  std::mutex mutex_;
+  std::list<TraceEvent> events_;
+  std::list<TraceCompleteEvent> complete_events_;
+  std::list<TraceCounter> counter_events_;
+  std::list<TraceCounterId> counter_id_events_;
+  std::list<TraceInstantEvent> instant_events_;
+};
+
+}  // namespace detail
+}  // namespace base
+
+#endif

--- a/src/base/trace_event/trace_events.cc
+++ b/src/base/trace_event/trace_events.cc
@@ -1,0 +1,107 @@
+#include "base/trace_event/trace_events.h"
+
+namespace base {
+namespace detail {
+
+namespace {
+void WriteArgumentsToStream(std::ostream& stream,
+                            const ArgumentPacker::StringArguments& args) {
+  stream << "\"args\":{";
+  for (const auto& arg : args) {
+    stream << "\"" << arg.first << "\":\"" << arg.second << "\"";
+    if (&arg != &args.back()) {
+      stream << ",";
+    }
+  }
+  stream << "}";
+}
+
+void WriteArgumentsToStream(std::ostream& stream,
+                            const ArgumentPacker::IntegerArguments& args) {
+  stream << "\"args\":{";
+  for (const auto& arg : args) {
+    stream << "\"" << arg.first << "\":" << arg.second;
+    if (&arg != &args.back()) {
+      stream << ",";
+    }
+  }
+  stream << "}";
+}
+}  // namespace
+
+void TraceEvent::WriteTo(std::ostream& stream) const {
+  stream << "{";
+  {
+    stream << "\"name\":\"" << name << "\",";
+    stream << "\"cat\":\"" << cat << "\",";
+    if (!id.empty()) {
+      stream << "\"id\":\"" << id << "\",";
+    }
+    stream << "\"ph\":\"" << ph << "\",";
+    stream << "\"ts\":" << ts << ",";
+    stream << "\"pid\":" << pid << ",";
+    stream << "\"tid\":" << tid << ",";
+    WriteArgumentsToStream(stream, args);
+  }
+  stream << "}";
+}
+
+void TraceCompleteEvent::WriteTo(std::ostream& stream) const {
+  stream << "{";
+  {
+    stream << "\"name\":\"" << name << "\",";
+    stream << "\"cat\":\"" << cat << "\",";
+    stream << "\"ph\":\"" << 'X' << "\",";
+    stream << "\"ts\":" << ts << ",";
+    stream << "\"dur\":" << dur << ",";
+    stream << "\"pid\":" << pid << ",";
+    stream << "\"tid\":" << tid << ",";
+    WriteArgumentsToStream(stream, args);
+  }
+  stream << "}";
+}
+
+void TraceCounter::WriteTo(std::ostream& stream) const {
+  stream << "{";
+  {
+    stream << "\"name\":\"" << name << "\",";
+    stream << "\"cat\":\"" << cat << "\",";
+    stream << "\"ph\":\"" << 'C' << "\",";
+    stream << "\"ts\":" << ts << ",";
+    stream << "\"pid\":" << pid << ",";
+    WriteArgumentsToStream(stream, args);
+  }
+  stream << "}";
+}
+
+void TraceCounterId::WriteTo(std::ostream& stream) const {
+  stream << "{";
+  {
+    stream << "\"name\":\"" << name << "\",";
+    stream << "\"cat\":\"" << cat << "\",";
+    stream << "\"id\":\"" << id << "\",";
+    stream << "\"ph\":\"" << 'C' << "\",";
+    stream << "\"ts\":" << ts << ",";
+    stream << "\"pid\":" << pid << ",";
+    WriteArgumentsToStream(stream, args);
+  }
+  stream << "}";
+}
+
+void TraceInstantEvent::WriteTo(std::ostream& stream) const {
+  stream << "{";
+  {
+    stream << "\"name\":\"" << name << "\",";
+    stream << "\"cat\":\"" << cat << "\",";
+    stream << "\"s\":\"" << s << "\",";
+    stream << "\"ph\":\"" << 'i' << "\",";
+    stream << "\"ts\":" << ts << ",";
+    stream << "\"pid\":" << pid << ",";
+    stream << "\"tid\":" << tid << ",";
+    WriteArgumentsToStream(stream, args);
+  }
+  stream << "}";
+}
+
+}  // namespace detail
+}  // namespace base

--- a/src/base/trace_event/trace_events.h
+++ b/src/base/trace_event/trace_events.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include <cstdint>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/trace_event/trace_argument_packer.h"
+
+namespace base {
+namespace detail {
+
+struct TraceEvent {
+  using Arguments = ArgumentPacker::StringArguments;
+
+  std::string name;
+  std::string cat;
+  std::string id;
+  char ph;
+  uint64_t ts;
+  uint64_t pid;
+  uint64_t tid;
+  Arguments args;
+
+  void WriteTo(std::ostream& stream) const;
+};
+
+struct TraceCompleteEvent {
+  using Arguments = ArgumentPacker::StringArguments;
+
+  std::string name;
+  std::string cat;
+  uint64_t ts;
+  uint64_t dur;
+  uint64_t pid;
+  uint64_t tid;
+  Arguments args;
+
+  void WriteTo(std::ostream& stream) const;
+};
+
+struct TraceCounter {
+  using Arguments = ArgumentPacker::IntegerArguments;
+
+  std::string name;
+  std::string cat;
+  uint64_t ts;
+  uint64_t pid;
+  Arguments args;
+
+  void WriteTo(std::ostream& stream) const;
+};
+
+struct TraceCounterId {
+  using Arguments = TraceCounter::Arguments;
+
+  std::string name;
+  std::string cat;
+  std::string id;
+  uint64_t ts;
+  uint64_t pid;
+  Arguments args;
+
+  void WriteTo(std::ostream& stream) const;
+};
+
+struct TraceInstantEvent {
+  using Arguments = ArgumentPacker::StringArguments;
+
+  std::string name;
+  std::string cat;
+  char s;
+  uint64_t ts;
+  uint64_t pid;
+  uint64_t tid;
+  Arguments args;
+
+  void WriteTo(std::ostream& stream) const;
+};
+
+}  // namespace detail
+}  // namespace base
+
+#endif

--- a/src/base/trace_event/trace_flow.h
+++ b/src/base/trace_event/trace_flow.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include "base/trace_event/trace_event_register.h"
+
+#define TRACE_EVENT_WITH_FLOW_BEGIN(categories, name, id, ...)                 \
+  ::base::detail::EventRegister::RegisterAsyncEvent(categories, name, id, 's', \
+                                                    ##__VA_ARGS__)
+
+#define TRACE_EVENT_WITH_FLOW_STEP(categories, name, id, ...)                  \
+  ::base::detail::EventRegister::RegisterAsyncEvent(categories, name, id, 't', \
+                                                    ##__VA_ARGS__)
+
+#define TRACE_EVENT_WITH_FLOW_END(categories, name, id, ...)                   \
+  ::base::detail::EventRegister::RegisterAsyncEvent(categories, name, id, 'f', \
+                                                    ##__VA_ARGS__)
+
+#else
+
+#define TRACE_EVENT_WITH_FLOW_BEGIN(categories, name, id, ...)
+#define TRACE_EVENT_WITH_FLOW_STEP(categories, name, id, ...)
+#define TRACE_EVENT_WITH_FLOW_END(categories, name, id, ...)
+
+#endif

--- a/src/base/trace_event/trace_flush.h
+++ b/src/base/trace_event/trace_flush.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include "base/trace_event/trace_event_register.h"
+
+#define TRACE_EVENT_FLUSH_TO_FILE(file) \
+  ::base::detail::EventRegister::FlushEventsToFile(file)
+
+#define TRACE_EVENT_FLUSH_TO_STREAM(stream) \
+  ::base::detail::EventRegister::FlushEventsToStream(stream)
+
+#else
+
+#define TRACE_EVENT_FLUSH_TO_FILE(file)
+#define TRACE_EVENT_FLUSH_TO_STREAM(stream)
+
+#endif

--- a/src/base/trace_event/trace_json_writer.h
+++ b/src/base/trace_event/trace_json_writer.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include <cstdint>
+#include <list>
+#include <string>
+
+#include "base/trace_event/trace_events.h"
+
+namespace base {
+namespace detail {
+
+class JsonWriter {
+ public:
+  static void WriteAll(std::ostream& stream,
+                       const std::list<TraceEvent>& generic_events,
+                       const std::list<TraceCompleteEvent>& complete_events,
+                       const std::list<TraceCounter>& counter_events,
+                       const std::list<TraceCounterId>& counter_id_events,
+                       const std::list<TraceInstantEvent>& instant_events) {
+    stream << "{\"traceEvents\":[\n";
+    bool written_data = false;
+    WriteEvents(stream, generic_events, written_data);
+    WriteEvents(stream, complete_events, written_data);
+    WriteEvents(stream, counter_events, written_data);
+    WriteEvents(stream, counter_id_events, written_data);
+    WriteEvents(stream, instant_events, written_data);
+    stream << "\n]}";
+  }
+
+ private:
+  template <typename T>
+  static void WriteEvents(std::ostream& stream,
+                          const T& events,
+                          bool& written_data) {
+    for (const auto& current_event : events) {
+      if (written_data) {
+        stream << ",\n";
+      }
+      current_event.WriteTo(stream);
+      written_data = true;
+    }
+  }
+};
+
+}  // namespace detail
+}  // namespace base
+
+#endif

--- a/src/base/trace_event/trace_metadata.h
+++ b/src/base/trace_event/trace_metadata.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include "base/trace_event/trace_event_register.h"
+
+#define TRACE_NAME_PROCESS(name)                                        \
+  ::base::detail::EventRegister::RegisterEvent("", "process_name", 'M', \
+                                               "name", name)
+
+#define TRACE_NAME_THREAD(name)                                                \
+  ::base::detail::EventRegister::RegisterEvent("", "thread_name", 'M', "name", \
+                                               name)
+
+#else
+
+#define TRACE_NAME_PROCESS(name)
+#define TRACE_NAME_THREAD(name)
+
+#endif

--- a/src/base/trace_event/trace_platform.cc
+++ b/src/base/trace_event/trace_platform.cc
@@ -1,13 +1,11 @@
 #include "base/trace_event/trace_platform.h"
 
-#if LIBBASE_IS_LINUX
+#if LIBBASE_IS_LINUX || LIBBASE_IS_MACOS
+#include <sys/syscall.h>
 #include <unistd.h>
 #elif LIBBASE_IS_WINDOWS
 #include <process.h>
 #include <windows.h>
-#elif LIBBASE_IS_MACOS
-#include <sys/syscall.h>
-#include <unistd.h>
 #endif
 
 namespace base {
@@ -17,18 +15,16 @@ uint64_t TracePlatform::GetPid() {
 #if LIBBASE_IS_LINUX || LIBBASE_IS_MACOS
   return ::getpid();
 #elif LIBBASE_IS_WINDOWS
-  return ::_getpid();
+  return ::GetCurrentProcessId();
 #endif
   return -1;
 }
 
 uint64_t TracePlatform::GetTid() {
-#if LIBBASE_IS_LINUX
-  return ::gettid();
+#if LIBBASE_IS_LINUX || LIBBASE_IS_MACOS
+  return ::syscall(SYS_gettid);
 #elif LIBBASE_IS_WINDOWS
   return ::GetCurrentThreadId();
-#elif LIBBASE_IS_MACOS
-  return ::syscall(SYS_gettid);
 #endif
   return -1;
 }

--- a/src/base/trace_event/trace_platform.cc
+++ b/src/base/trace_event/trace_platform.cc
@@ -16,8 +16,9 @@ uint64_t TracePlatform::GetPid() {
   return ::getpid();
 #elif LIBBASE_IS_WINDOWS
   return ::GetCurrentProcessId();
-#endif
+#else
   return static_cast<uint64_t>(-1);
+#endif
 }
 
 uint64_t TracePlatform::GetTid() {
@@ -25,8 +26,9 @@ uint64_t TracePlatform::GetTid() {
   return ::syscall(SYS_gettid);
 #elif LIBBASE_IS_WINDOWS
   return ::GetCurrentThreadId();
-#endif
+#else
   return static_cast<uint64_t>(-1);
+#endif
 }
 
 }  // namespace detail

--- a/src/base/trace_event/trace_platform.cc
+++ b/src/base/trace_event/trace_platform.cc
@@ -17,7 +17,7 @@ uint64_t TracePlatform::GetPid() {
 #elif LIBBASE_IS_WINDOWS
   return ::GetCurrentProcessId();
 #endif
-  return -1;
+  return static_cast<uint64_t>(-1);
 }
 
 uint64_t TracePlatform::GetTid() {
@@ -26,7 +26,7 @@ uint64_t TracePlatform::GetTid() {
 #elif LIBBASE_IS_WINDOWS
   return ::GetCurrentThreadId();
 #endif
-  return -1;
+  return static_cast<uint64_t>(-1);
 }
 
 }  // namespace detail

--- a/src/base/trace_event/trace_platform.cc
+++ b/src/base/trace_event/trace_platform.cc
@@ -1,0 +1,37 @@
+#include "base/trace_event/trace_platform.h"
+
+#if LIBBASE_IS_LINUX
+#include <unistd.h>
+#elif LIBBASE_IS_WINDOWS
+#include <process.h>
+#include <windows.h>
+#elif LIBBASE_IS_MACOS
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
+
+namespace base {
+namespace detail {
+
+uint64_t TracePlatform::GetPid() {
+#if LIBBASE_IS_LINUX || LIBBASE_IS_MACOS
+  return ::getpid();
+#elif LIBBASE_IS_WINDOWS
+  return ::_getpid();
+#endif
+  return -1;
+}
+
+uint64_t TracePlatform::GetTid() {
+#if LIBBASE_IS_LINUX
+  return ::gettid();
+#elif LIBBASE_IS_WINDOWS
+  return ::GetCurrentThreadId();
+#elif LIBBASE_IS_MACOS
+  return ::syscall(SYS_gettid);
+#endif
+  return -1;
+}
+
+}  // namespace detail
+}  // namespace base

--- a/src/base/trace_event/trace_platform.h
+++ b/src/base/trace_event/trace_platform.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include <cstdint>
+#include <sstream>
+#include <thread>
+
+namespace base {
+namespace detail {
+
+class TracePlatform {
+ public:
+  static uint64_t GetPid();
+  static uint64_t GetTid();
+};
+
+}  // namespace detail
+}  // namespace base
+
+#endif

--- a/src/base/trace_event/trace_signal.h
+++ b/src/base/trace_event/trace_signal.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#ifndef LIBBASE_TRACING_DISABLE
+
+#include "base/trace_event/trace_event_register.h"
+
+#define TRACE_SIGNAL(categories, name, ...)                                  \
+  ::base::detail::EventRegister::RegisterInstantEvent(categories, name, 'g', \
+                                                      ##__VA_ARGS__)
+
+#define TRACE_SIGNAL_THREAD(categories, name, ...)                           \
+  ::base::detail::EventRegister::RegisterInstantEvent(categories, name, 't', \
+                                                      ##__VA_ARGS__)
+
+#define TRACE_SIGNAL_PROCESS(categories, name, ...)                          \
+  ::base::detail::EventRegister::RegisterInstantEvent(categories, name, 'p', \
+                                                      ##__VA_ARGS__)
+
+#else
+
+#define TRACE_SIGNAL(categories, name, ...)
+#define TRACE_SIGNAL_THREAD(categories, name, ...)
+#define TRACE_SIGNAL_PROCESS(categories, name, ...)
+
+#endif


### PR DESCRIPTION
This commit introduces simple tracing framework based on what
Chromium offers. Similar macros are exposed to the users but with
variadic arguments (no need to change macro name to add/remove
arguments). For now, the only configuration present is either
to enable or disable all traces. Furthermore, current implementation
is quite basic, meaning that there is still a lot of room for
performance and memory-related optimizations down the road.

Currently these tracing options are available:
* Trace event (begin+end or per-scope)
* Async trace events (begin/step/end)
* Trace counters
* Trace events with flow ("arrows")
* Trace signals