### PR TITLE
Build Fix for GCC 12.2.0 , Fedora

### DIFF
--- a/src/base/sequence_checker.cc
+++ b/src/base/sequence_checker.cc
@@ -1,5 +1,7 @@
 #include "base/sequence_checker.h"
 
+#include <utility>
+
 namespace base {
 
 SequenceChecker::SequenceChecker()

--- a/src/base/synchronization/auto_signaller.cc
+++ b/src/base/synchronization/auto_signaller.cc
@@ -2,6 +2,8 @@
 
 #include "base/synchronization/waitable_event.h"
 
+#include <utility>
+
 namespace base {
 
 AutoSignaller::AutoSignaller(WaitableEvent* event) : event_(event) {}


### PR DESCRIPTION
While building on Fedora with GCC 12.2, the CMake throws the following error in ```src/base/sequence_checker.cc``` & ```src/base/synchronization/auto_signaller.cc```

```
/libbase/src/base/sequence_checker.cc: In constructor ‘base::SequenceChecker::SequenceChecker(base::SequenceChecker&&)’:
/libbase/src/base/sequence_checker.cc:14:23: error: ‘exchange’ is not a member of ‘std’
   14 |   sequence_id_ = std::exchange(other.sequence_id_, std::nullopt);
      |                       ^~~~~~~~
/libbase/src/base/sequence_checker.cc: In member function ‘base::SequenceChecker& base::SequenceChecker::operator=(base::SequenceChecker&&)’:
/libbase/src/base/sequence_checker.cc:23:23: error: ‘exchange’ is not a member of ‘std’
   23 |   sequence_id_ = std::exchange(other.sequence_id_, std::nullopt);

/libbase/src/base/synchronization/auto_signaller.cc: In constructor ‘base::AutoSignaller::AutoSignaller(base::AutoSignaller&&)’:
/libbase/src/base/synchronization/auto_signaller.cc:16:19: error: ‘exchange’ is not a member of ‘std’
   16 |     : event_(std::exchange(other.event_, nullptr)) {}
      |                   ^~~~~~~~
/libbase/src/base/synchronization/auto_signaller.cc: In member function ‘base::AutoSignaller& base::AutoSignaller::operator=(base::AutoSignaller&&)’:
/libbase/src/base/synchronization/auto_signaller.cc:23:19: error: ‘exchange’ is not a member of ‘std’
   23 |     event_ = std::exchange(other.event_, nullptr);

```
This has been fixed by adding ```<utility>``` header in ```src/base/sequence_checker.cc``` and ```src/base/synchronization/auto_signaller.cc```.