### PR TITLE
[#39] Integrate with existing (main) Windows GUI thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 3.13)
 
 # Core modules
 option(LIBBASE_BUILD_MODULE_NET "Build networking module." ON)
+option(LIBBASE_BUILD_MODULE_WIN "Build WinApi integration module." ON)
 # Optional modules
 option(LIBBASE_BUILD_MODULE_WX "Build wxWidgets integration module." OFF)
 
@@ -62,6 +63,11 @@ option(LIBBASE_BUILD_ASAN "Build with Address Sanitizer enabled" OFF)
 option(LIBBASE_BUILD_TSAN "Build with Thread Sanitizer enabled" OFF)
 
 
+if(LIBBASE_BUILD_MODULE_WIN AND NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  set(LIBBASE_BUILD_MODULE_WIN OFF CACHE BOOL "" FORCE)
+endif()
+
+
 #
 # Compiler setup
 #
@@ -74,6 +80,7 @@ include(SetupCompileFlags)
 # - LIBBASE_OPT_CLANG_TIDY_PROPERTIES - optional C++ property for clang-tidy use
 setup_compile_flags()
 
+message(STATUS "System: ${CMAKE_SYSTEM_NAME}")
 message(STATUS "Compiler: ${CMAKE_CXX_COMPILER}")
 message(STATUS "Compiler flags: '${LIBBASE_COMPILE_FLAGS}'")
 message(STATUS "Linker flags: '${LIBBASE_LINK_FLAGS}'")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_subdirectory(simple)
 
+if(LIBBASE_BUILD_MODULE_WIN)
+  add_subdirectory(winapi_integration)
+endif ()
+
 if(LIBBASE_BUILD_MODULE_WX)
   add_subdirectory(wxwidgets_integration)
 endif()

--- a/examples/winapi_integration/CMakeLists.txt
+++ b/examples/winapi_integration/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_executable(winapi_integration_example
+  WIN32
+  ""
+)
+
+target_compile_options(winapi_integration_example
+  PRIVATE
+    ${LIBBASE_COMPILE_FLAGS}
+)
+
+target_link_libraries(winapi_integration_example
+  PRIVATE
+    libbase
+    libbase_win
+)
+
+target_sources(winapi_integration_example
+  PRIVATE
+    main.cc
+)

--- a/examples/winapi_integration/main.cc
+++ b/examples/winapi_integration/main.cc
@@ -1,0 +1,97 @@
+#ifndef UNICODE
+#define UNICODE
+#endif
+
+#include <thread>
+
+#include "base/message_loop/win/win_message_loop_attachment.h"
+#include "base/platform/windows.h"
+#include "base/threading/thread_pool.h"
+
+LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+void SetWindowTitle(HWND hWnd, const wchar_t* title) {
+  SetWindowText(hWnd, title);
+}
+
+int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR, int nCmdShow) {
+  // Setup libbase attachment to main Window thread's message loop
+  auto loopAttachment = base::win::WinMessageLoopAttachment::TryCreate();
+  if (!loopAttachment) {
+    return 0;
+  }
+
+  // Register the window class.
+  const wchar_t CLASS_NAME[] = L"Window Class";
+  WNDCLASS wc = {};
+  wc.lpfnWndProc = &WindowProc;
+  wc.hInstance = hInstance;
+  wc.lpszClassName = CLASS_NAME;
+  RegisterClass(&wc);
+
+  // Adjust window size to account for borders and title bar
+  RECT rect = {0, 0, 800, 600};
+  AdjustWindowRect(&rect, WS_OVERLAPPEDWINDOW, FALSE);
+
+  HWND hwnd =
+      CreateWindowEx(0, CLASS_NAME, L"Default title", WS_OVERLAPPEDWINDOW,
+                     CW_USEDEFAULT, CW_USEDEFAULT, rect.right - rect.left,
+                     rect.bottom - rect.top, NULL, NULL, hInstance, NULL);
+  if (hwnd == NULL) {
+    return 0;
+  }
+
+  ShowWindow(hwnd, nCmdShow);
+
+  // Some example testing
+  loopAttachment->TaskRunner()->PostTask(
+      FROM_HERE, base::BindOnce(&SetWindowTitle, hwnd,
+                                L"Changed window title from post-task"));
+  loopAttachment->TaskRunner()->PostDelayedTask(
+      FROM_HERE,
+      base::BindOnce(&SetWindowTitle, hwnd, L"Delayed task executed as well!"),
+      base::Seconds(3));
+
+  base::ThreadPool threadPool{4};
+  threadPool.Start();
+  threadPool.GetTaskRunner()->PostTaskAndReplyWithResult(
+      FROM_HERE, base::BindOnce([]() -> const wchar_t* {
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+        return L"Greetings from thread pool!";
+      }),
+      base::BindOnce(&SetWindowTitle, hwnd));
+
+  // Run the message loop.
+  MSG msg = {};
+  while (GetMessage(&msg, NULL, 0, 0) > 0) {
+    TranslateMessage(&msg);
+    DispatchMessage(&msg);
+  }
+
+  return 0;
+}
+
+LRESULT CALLBACK WindowProc(HWND hwnd,
+                            UINT uMsg,
+                            WPARAM wParam,
+                            LPARAM lParam) {
+  switch (uMsg) {
+    case WM_DESTROY:
+      PostQuitMessage(0);
+      return 0;
+
+    case WM_CLOSE:
+      DestroyWindow(hwnd);
+      return 0;
+
+    case WM_PAINT: {
+      PAINTSTRUCT ps;
+      HDC hdc = BeginPaint(hwnd, &ps);
+      FillRect(hdc, &ps.rcPaint, (HBRUSH)(COLOR_WINDOW + 1));
+      EndPaint(hwnd, &ps);
+      return 0;
+    }
+  }
+
+  return DefWindowProc(hwnd, uMsg, wParam, lParam);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ if (LIBBASE_FEATURE_TRACING)
   string(APPEND LIBBASE_FEATURE_DEFINES "LIBBASE_ENABLE_TRACING")
 endif()
 
+
 #
 # Library
 #
@@ -166,6 +167,44 @@ if(LIBBASE_BUILD_MODULE_NET)
       base/net/result.h
       base/net/simple_url_loader.cc
       base/net/simple_url_loader.h
+  )
+endif()
+
+
+#
+# Library integration module - win (WinApi)
+#
+
+if(LIBBASE_BUILD_MODULE_WIN)
+  add_library(libbase_win STATIC "")
+
+  target_compile_features(libbase_win PUBLIC cxx_std_17)
+  target_compile_options(libbase_win PRIVATE ${LIBBASE_COMPILE_FLAGS})
+  target_compile_definitions(libbase_win PUBLIC
+    ${LIBBASE_DEFINES}
+    ${LIBBASE_FEATURE_DEFINES})
+  target_compile_definitions(libbase_win
+      INTERFACE LIBBASE_MODULE_WIN
+  )
+  set_target_properties(libbase_win PROPERTIES
+    CXX_EXTENSIONS ON
+    ${LIBBASE_OPT_CLANG_TIDY_PROPERTIES})
+
+  target_include_directories(libbase_win PUBLIC
+      $<BUILD_INTERFACE:${libbase_SOURCE_DIR}/src/>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libbase>
+  )
+
+  target_link_libraries(libbase_win PUBLIC
+    ${LIBBASE_LINK_FLAGS}
+    libbase
+    Threads::Threads
+    glog::glog)
+
+  target_sources(libbase_win
+    PRIVATE
+      base/message_loop/win/win_message_loop_attachment.cc
+      base/message_loop/win/win_message_loop_attachment.h
   )
 endif()
 

--- a/src/base/message_loop/win/win_message_loop_attachment.cc
+++ b/src/base/message_loop/win/win_message_loop_attachment.cc
@@ -1,0 +1,130 @@
+#ifndef UNICODE
+#define UNICODE
+#endif
+
+#include "base/message_loop/win/win_message_loop_attachment.h"
+
+#include "base/logging.h"
+#include "base/message_loop/message_pump_impl.h"
+#include "base/threading/task_runner_impl.h"
+
+namespace base {
+namespace win {
+
+namespace {
+inline static const UINT WM_LIBBASE_EXECUTE_TASK = WM_USER + 0;
+inline static const wchar_t LIBBASE_CLASS_NAME[] = L"libbaseMessageOnlyWindow";
+
+thread_local WinMessageLoopAttachment* g_current_instance = nullptr;
+
+HWND CreateMessageOnlyWindow(WNDPROC wndProc) {
+  static int static_in_this_module = 0;
+
+  HMODULE hModule = nullptr;
+  GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                        GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                    reinterpret_cast<LPCWSTR>(&static_in_this_module),
+                    &hModule);
+
+  WNDCLASS window_class = {};
+  window_class.lpfnWndProc = wndProc;
+  window_class.lpszClassName = LIBBASE_CLASS_NAME;
+  window_class.hInstance = NULL;  // hModule;
+  window_class.hbrBackground = reinterpret_cast<HBRUSH>(COLOR_BTNFACE + 1);
+  RegisterClass(&window_class);
+
+  return CreateWindow(LIBBASE_CLASS_NAME, L"", 0, CW_USEDEFAULT, CW_USEDEFAULT,
+                      CW_USEDEFAULT, CW_USEDEFAULT, HWND_MESSAGE, nullptr,
+                      hModule, nullptr);
+}
+}  // namespace
+
+//
+// WinMessagePumpImpl
+//
+
+namespace detail {
+class WinMessagePumpImpl : public MessagePumpImpl {
+ public:
+  WinMessagePumpImpl(size_t executors_count, HWND hwnd)
+      : MessagePumpImpl(executors_count), hwnd_(hwnd) {}
+
+  // MessagePump
+  bool QueuePendingTask(PendingTask pending_task) override {
+    if (MessagePumpImpl::QueuePendingTask(std::move(pending_task))) {
+      PostMessage(hwnd_, WM_LIBBASE_EXECUTE_TASK, 0, 0);
+      return true;
+    }
+    return false;
+  }
+
+ private:
+  HWND hwnd_;
+};
+}  // namespace detail
+
+//
+// WinMessageLoopAttachment
+//
+
+// static
+std::unique_ptr<WinMessageLoopAttachment>
+WinMessageLoopAttachment::TryCreate() {
+  if (auto hWnd =
+          CreateMessageOnlyWindow(&WinMessageLoopAttachment::WindowProc)) {
+    return std::unique_ptr<WinMessageLoopAttachment>(
+        new WinMessageLoopAttachment(hWnd));
+  }
+
+  return {};
+}
+
+WinMessageLoopAttachment::WinMessageLoopAttachment(HWND hWnd)
+    : hWnd_(hWnd),
+      sequence_id_(base::detail::SequenceIdGenerator::GetNextSequenceId()),
+      message_pump_(std::make_shared<detail::WinMessagePumpImpl>(1, hWnd_)),
+      task_runner_(SingleThreadTaskRunnerImpl::Create(
+          message_pump_,
+          sequence_id_,
+          0,
+          DelayedTaskManagerSharedInstance::GetOrCreateSharedInstance())),
+      scoped_sequence_id_(sequence_id_),
+      scoped_task_runner_handle_(task_runner_) {
+  DCHECK_EQ(g_current_instance, nullptr);
+  g_current_instance = this;
+}
+
+WinMessageLoopAttachment::~WinMessageLoopAttachment() {
+  DCHECK_NE(g_current_instance, nullptr);
+  g_current_instance = nullptr;
+
+  message_pump_->Stop({});
+  DestroyWindow(hWnd_);
+}
+
+std::shared_ptr<SingleThreadTaskRunner> WinMessageLoopAttachment::TaskRunner()
+    const {
+  return task_runner_;
+}
+
+// static
+LRESULT CALLBACK WinMessageLoopAttachment::WindowProc(HWND hWnd,
+                                                      UINT uMsg,
+                                                      WPARAM wParam,
+                                                      LPARAM lParam) {
+  if (uMsg == WM_LIBBASE_EXECUTE_TASK) {
+    DCHECK_NE(g_current_instance, nullptr);
+
+    const MessagePump::ExecutorId executor_id = 0;
+    if (auto pending_task =
+            g_current_instance->message_pump_->GetNextPendingTask(executor_id,
+                                                                  false)) {
+      std::move(pending_task.task).Run();
+    }
+  }
+
+  return DefWindowProc(hWnd, uMsg, wParam, lParam);
+}
+
+}  // namespace win
+}  // namespace base

--- a/src/base/message_loop/win/win_message_loop_attachment.h
+++ b/src/base/message_loop/win/win_message_loop_attachment.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#if defined(LIBBASE_IS_WINDOWS)
+
+#include <memory>
+
+#include "base/message_loop/message_loop.h"
+#include "base/platform/windows.h"
+#include "base/sequenced_task_runner_helpers.h"
+#include "base/single_thread_task_runner.h"
+#include "base/threading/delayed_task_manager_shared_instance.h"
+#include "base/threading/sequenced_task_runner_handle.h"
+
+namespace base {
+namespace win {
+
+class WinMessageLoopAttachment {
+ public:
+  static std::unique_ptr<WinMessageLoopAttachment> TryCreate();
+
+ public:
+  ~WinMessageLoopAttachment();
+
+  std::shared_ptr<SingleThreadTaskRunner> TaskRunner() const;
+
+ private:
+  WinMessageLoopAttachment(HWND hWnd);
+
+  static LRESULT CALLBACK WindowProc(HWND hWnd,
+                                     UINT uMsg,
+                                     WPARAM wParam,
+                                     LPARAM lParam);
+
+  HWND hWnd_;
+  SequenceId sequence_id_;
+  std::shared_ptr<MessagePump> message_pump_;
+  std::shared_ptr<SingleThreadTaskRunner> task_runner_;
+  base::detail::ScopedSequenceIdSetter scoped_sequence_id_;
+  SequencedTaskRunnerHandle scoped_task_runner_handle_;
+};
+
+}  // namespace win
+}  // namespace base
+
+#endif  // defined(LIBBASE_IS_WINDOWS)

--- a/src/base/platform/windows.h
+++ b/src/base/platform/windows.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#if defined(LIBBASE_IS_WINDOWS)
+
+#if defined(NOMINMAX)
+
+#include <Windows.h>
+
+#else  // defined(NOMINMAX)
+
+#define NOMINMAX
+#include <Windows.h>
+#undef NOMINMAX
+
+#endif  // !defined(NOMINMAX)
+
+#endif  // defined(LIBBASE_IS_WINDOWS)

--- a/src/base/trace_event/trace_platform.cc
+++ b/src/base/trace_event/trace_platform.cc
@@ -10,8 +10,8 @@
 #include <pthread.h>
 #endif
 #elif defined(LIBBASE_IS_WINDOWS)
-#include <Windows.h>
 #include <process.h>
+#include "base/platform/windows.h"
 #endif
 
 namespace base {


### PR DESCRIPTION
This commit adds a new class template called `base::WinThreadAttachment` which can be used to integrate libbase's cross-thread post-tasking with Windows native message queue system.

Example usage:

```cpp
  HWND hwnd = CreateWindowEx(/* ... */);

  // This must be done after creating a window and before main loop and
  // outlive the main loop.
  // `LIBBASE_TASK_MSG_ID` here is some custom integer provided by user
  // of this library that will not be used as any other message ID in
  // the app (e.g. `WM_APP+0`).
  base::WinThreadAttachment<LIBBASE_TASK_MSG_ID> mainThread{hwnd};
  // As long as the `mainThread` lives, current thread will have
  // associated task runner that will post task to Window's message
  // queue and all such tasks will be executed between other messages
  // on that queue.

  // Main loop example
  MSG msg = {};
  while (GetMessage(&msg, NULL, 0, 0) > 0) {
    TranslateMessage(&msg);
    DispatchMessage(&msg);
  }
```

Apart from that, new (Windows-only) example called `win32` has been added to showcase new functionality.