### PR TITLE
Drop gcc on MacOS CI builds as its not reliable, test newer versions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14, macos-15]
+        os: [macos-13, macos-14, macos-latest]
         build_type: [Release, Debug]
         compiler: [
           {name: Clang, cc: clang, cxx: clang++, package: true}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,12 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13]
+        os: [macos-13, macos-14, macos-15]
         build_type: [Release, Debug]
         compiler: [
-          {name: GCC 12, cc: gcc-12, cxx: g++-12, brew_ver: gcc@12, package: false},
-          {name: GCC 14, cc: gcc-14, cxx: g++-14, brew_ver: gcc@14, package: true},
-          {name: Clang 14, cc: clang, cxx: clang++, package: true}
+          {name: Clang, cc: clang, cxx: clang++, package: true}
         ]
 
     env:
@@ -31,14 +29,6 @@ jobs:
       CXX: ${{ matrix.compiler.cxx }}
 
     steps:
-      - name: (Optional) Compiler instalation
-        if: ${{ matrix.os == 'macos-13' && startsWith(matrix.compiler.cc, 'gcc') }}
-        run: |
-          if ! command -v ${{ matrix.compiler.cc }} &> /dev/null
-          then
-            brew install ${{ matrix.compiler.brew_ver }}
-          fi
-
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
This commit drops MacOS builds with GCC in CI as support for GCC is
not reliable enough. For simplicity let's stick with just default clang version.

Also include builds on MacOS 14 and latest - intended to be 15 but at
the moment its in preview and not fully reliable (e.g. missing things like `ninja`).