### PR TITLE
Implement base::BindToCurrentSequence helper

### DIFF
--- a/docs/features/callbacks.rst
+++ b/docs/features/callbacks.rst
@@ -455,6 +455,10 @@ This will result in creating a new callback that - when executed - will
 post-task the original callback to the target task runner. This is possible with
 :func:`base::BindPostTask`.
 
+If you want to bind callback to current sequence (the task runner your code is
+being executed right now) you can also use :func:`base::BindToCurrentSequence`
+function.
+
 .. admonition:: Example - :func:`base::BindPostTask`
    :class: admonition-example-code
 
@@ -471,8 +475,15 @@ post-task the original callback to the target task runner. This is possible with
       // Our code
       void WorkManager::StartSomeWork() {
         auto on_done_callback = base::BindOnce(&WorkManager::WorkDone, weak_this_);
+
+        // Bind callback specifically to `current_task_runner_` regardless of on which
+        // task runner this function is executed
         DoSomeWorkAsync(
             base::BindPostTask(current_task_runner_, std::move(on_done_callback)));
+
+        // ... or assuming you're running on `current_task_runner_` right now, this is
+        // equivalent to calling:
+        DoSomeWorkAsync(base::BindToCurrentSequence(std::move(on_done_callback)));
       }
 
       void WorkManager::WorkDone() {

--- a/src/base/bind_post_task.h
+++ b/src/base/bind_post_task.h
@@ -4,6 +4,7 @@
 
 #include "base/callback.h"
 #include "base/task_runner.h"
+#include "base/threading/sequenced_task_runner_handle.h"
 
 namespace base {
 
@@ -67,6 +68,30 @@ RepeatingCallback<Return(Arguments...)> BindPostTask(
       &Helper::Run,
       base::Owned(std::make_unique<Helper>(
           std::move(task_runner), std::move(callback), std::move(location))));
+}
+
+template <typename Return, typename... Arguments>
+OnceCallback<Return(Arguments...)> BindToCurrentSequence(
+    OnceCallback<Return(Arguments...)> callback,
+    SourceLocation location) {
+  static_assert(
+      std::is_same_v<Return, void>,
+      "Cannot BinToCurrentSequence callback with non-void return type");
+
+  return BindPostTask(SequencedTaskRunnerHandle::Get(), std::move(callback),
+                      std::move(location));
+}
+
+template <typename Return, typename... Arguments>
+RepeatingCallback<Return(Arguments...)> BindToCurrentSequence(
+    RepeatingCallback<Return(Arguments...)> callback,
+    SourceLocation location) {
+  static_assert(
+      std::is_same_v<Return, void>,
+      "Cannot BinToCurrentSequence callback with non-void return type");
+
+  return BindPostTask(SequencedTaskRunnerHandle::Get(), std::move(callback),
+                      std::move(location));
 }
 
 }  // namespace base

--- a/src/base/threading/sequenced_task_runner_handle.cc
+++ b/src/base/threading/sequenced_task_runner_handle.cc
@@ -11,7 +11,8 @@ thread_local SequencedTaskRunnerHandle* g_handle = nullptr;
 
 // static
 const std::shared_ptr<SequencedTaskRunner>& SequencedTaskRunnerHandle::Get() {
-  CHECK(g_handle);
+  CHECK(g_handle) << "Attempted to access SequencedTaskRunner handle on a "
+                     "thread without task runner";
   return g_handle->task_runner_;
 }
 


### PR DESCRIPTION
This commit adds a new helper that binds a callback execution to sequence that code binding it is executed on. This means that when the resulting callback will be executed, it will post-task execution of the original one to the task runner/sequence on which it wound bound (to "current" - at the time - sequence).

This is particularly useful if you're passing a result/on-done callback to another object which could work on different thread/sequence and you want to ensure that it is executed on your original sequence.