### PR TITLE
[#41] Implement network request cancellation

### DIFF
--- a/examples/simple/main.cc
+++ b/examples/simple/main.cc
@@ -157,8 +157,9 @@ void NetExample() {
         for (const auto& [h, v] : response.headers) {
           LOG(INFO) << "  " << h << ": " << v;
         }
-        LOG(INFO) << "Content:\n"
-                  << std::string{response.data.begin(), response.data.end()};
+        LOG_IF(INFO, !response.data.empty())
+            << "Content:\n"
+            << std::string{response.data.begin(), response.data.end()};
         event->Signal();
       },
       &finished_event);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,8 @@ target_sources(libbase
     base/net/impl/net_thread_impl.h
     base/net/impl/net_thread.cc
     base/net/impl/net_thread.h
+    base/net/request_cancellation_token.cc
+    base/net/request_cancellation_token.h
     base/net/resource_request.h
     base/net/resource_response.h
     base/net/result.h

--- a/src/base/net/impl/net_thread.cc
+++ b/src/base/net/impl/net_thread.cc
@@ -1,10 +1,16 @@
 #include "base/net/impl/net_thread.h"
 
+#include <atomic>
+
 #include "base/logging.h"
 #include "base/net/impl/net_thread_impl.h"
 
 namespace base {
 namespace net {
+
+namespace {
+std::atomic_size_t g_request_id_counter_ = 0;
+}
 
 // static
 NetThread& NetThread::GetInstance() {
@@ -26,14 +32,25 @@ void NetThread::Stop() {
   impl_.reset();
 }
 
-void NetThread::EnqueueDownload(
+RequestCancellationToken NetThread::EnqueueDownload(
     ResourceRequest request,
     std::optional<size_t> max_response_size_bytes,
     OnceCallback<void(ResourceResponse)> on_done_callback) {
   DCHECK(impl_);
 
+  RequestCancellationToken cancellation_token{
+      g_request_id_counter_.fetch_add(1)};
+
   impl_->EnqueueDownload(std::move(request), std::move(max_response_size_bytes),
-                         std::move(on_done_callback));
+                         cancellation_token, std::move(on_done_callback));
+
+  return cancellation_token;
+}
+
+void NetThread::CancelRequest(RequestCancellationToken cancellation_token) {
+  DCHECK(impl_);
+
+  impl_->CancelRequest(std::move(cancellation_token));
 }
 
 }  // namespace net

--- a/src/base/net/impl/net_thread.h
+++ b/src/base/net/impl/net_thread.h
@@ -4,6 +4,7 @@
 #include <optional>
 
 #include "base/callback.h"
+#include "base/net/request_cancellation_token.h"
 #include "base/net/resource_request.h"
 #include "base/net/resource_response.h"
 
@@ -17,9 +18,12 @@ class NetThread {
   void Start();
   void Stop();
 
-  void EnqueueDownload(ResourceRequest request,
-                       std::optional<size_t> max_response_size_bytes,
-                       OnceCallback<void(ResourceResponse)> on_done_callback);
+  RequestCancellationToken EnqueueDownload(
+      ResourceRequest request,
+      std::optional<size_t> max_response_size_bytes,
+      OnceCallback<void(ResourceResponse)> on_done_callback);
+
+  void CancelRequest(RequestCancellationToken cancellation_token);
 
  private:
   class NetThreadImpl;

--- a/src/base/net/impl/net_thread_impl.cc
+++ b/src/base/net/impl/net_thread_impl.cc
@@ -21,6 +21,7 @@ Result CurlCodeToNetResult(CURLcode code) {
 struct NetThread::NetThreadImpl::DownloadInfo {
   ResourceRequest request;
   std::optional<size_t> max_response_size_bytes;
+  RequestCancellationToken cancellation_token;
 
   struct curl_slist* headers = nullptr;
 
@@ -70,6 +71,7 @@ void NetThread::NetThreadImpl::Stop() {
 void NetThread::NetThreadImpl::EnqueueDownload(
     ResourceRequest request,
     std::optional<size_t> max_response_size_bytes,
+    RequestCancellationToken cancellation_token,
     OnceCallback<void(ResourceResponse)> on_done_callback) {
   DCHECK(thread_);
   DCHECK(on_done_callback);
@@ -79,10 +81,24 @@ void NetThread::NetThreadImpl::EnqueueDownload(
     pending_add_downloads_.push_back(DownloadInfo{
         std::move(request),
         std::move(max_response_size_bytes),
+        std::move(cancellation_token),
         nullptr,
         {},
         std::move(on_done_callback),
     });
+  }
+
+  not_modified_.clear();
+  curl_multi_wakeup(multi_handle_);
+}
+
+void NetThread::NetThreadImpl::CancelRequest(
+    RequestCancellationToken cancellation_token) {
+  DCHECK(thread_);
+
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    pending_cancel_downloads_.push_back(std::move(cancellation_token));
   }
 
   not_modified_.clear();
@@ -107,11 +123,19 @@ void NetThread::NetThreadImpl::RunLoop_NetThread() {
 void NetThread::NetThreadImpl::ProcessPendingActions_NetThread() {
   if (!not_modified_.test_and_set()) {
     std::unique_lock<std::mutex> lock(mutex_);
+
     for (DownloadInfo& download : pending_add_downloads_) {
       EnqueueDownload_NetThread(download);
     }
     pending_add_downloads_.clear();
-    // TODO: handle pending_cancel_downloads_
+
+    for (RequestCancellationToken cancellation_token :
+         pending_cancel_downloads_) {
+      if (CURL* cancelled_handle =
+              FindHandleByCancellationToken_NetThread(cancellation_token)) {
+        DownloadFinished_NetThread(cancelled_handle, Result::kAborted);
+      }
+    }
   }
 }
 
@@ -183,8 +207,10 @@ void NetThread::NetThreadImpl::EnqueueDownload_NetThread(
   }
 
   // Save download request/response data
-  active_downloads_.insert({easy_handle, std::move(download_info)});
-  const auto& inserted_info = active_downloads_[easy_handle];
+  auto [iter, inserted] =
+      active_downloads_.emplace(easy_handle, std::move(download_info));
+  DCHECK(inserted);
+  const auto& inserted_info = *iter;
 
   // WARNING: Lambda has to be converted to function pointer or it will crash!
   curl_easy_setopt(easy_handle, CURLOPT_WRITEDATA, (void*)(&inserted_info));
@@ -209,15 +235,17 @@ void NetThread::NetThreadImpl::EnqueueDownload_NetThread(
 
 void NetThread::NetThreadImpl::DownloadFinished_NetThread(CURL* finished_curl,
                                                           Result result) {
-  CHECK_GT(active_downloads_.count(finished_curl), 0);
+  auto download_iter = active_downloads_.find(finished_curl);
+  CHECK(download_iter != active_downloads_.end());
 
-  auto& download = active_downloads_[finished_curl];
+  auto& download = download_iter->second;
 
   // Result
   download.response.result = result;
 
   // Response code
-  if (download.response.result == Result::kOk) {
+  if (download.response.result == Result::kOk ||
+      download.response.result == Result::kAborted) {
     long http_code = 0;
     curl_easy_getinfo(finished_curl, CURLINFO_RESPONSE_CODE, &http_code);
     download.response.code = static_cast<int>(http_code);
@@ -272,11 +300,15 @@ void NetThread::NetThreadImpl::DownloadFinished_NetThread(CURL* finished_curl,
 void NetThread::NetThreadImpl::RemoveDownload_NetThread(CURL* finished_curl) {
   // Remove the completed request from multi-handle
   curl_multi_remove_handle(multi_handle_, finished_curl);
-  if (active_downloads_.count(finished_curl) > 0) {
-    if (active_downloads_[finished_curl].headers) {
-      curl_slist_free_all(active_downloads_[finished_curl].headers);
+
+  auto download_iter = active_downloads_.find(finished_curl);
+  if (download_iter != active_downloads_.end()) {
+    auto& download = download_iter->second;
+    if (download.headers) {
+      curl_slist_free_all(download.headers);
     }
   }
+
   curl_easy_cleanup(finished_curl);
 
   // Remove the handle from our list
@@ -296,6 +328,16 @@ void NetThread::NetThreadImpl::AbortAllDownloads_NetThread() {
   }
 
   active_downloads_.clear();
+}
+
+CURL* NetThread::NetThreadImpl::FindHandleByCancellationToken_NetThread(
+    RequestCancellationToken cancellation_token) const {
+  for (const auto& [easy_handle, info] : active_downloads_) {
+    if (info.cancellation_token == cancellation_token) {
+      return easy_handle;
+    }
+  }
+  return nullptr;
 }
 
 }  // namespace net

--- a/src/base/net/request_cancellation_token.cc
+++ b/src/base/net/request_cancellation_token.cc
@@ -1,0 +1,15 @@
+#include "base/net/request_cancellation_token.h"
+
+namespace base {
+namespace net {
+
+RequestCancellationToken::RequestCancellationToken(size_t request_id)
+    : request_id_(request_id) {}
+
+bool RequestCancellationToken::operator==(
+    const RequestCancellationToken& other) const {
+  return request_id_ == other.request_id_;
+}
+
+}  // namespace net
+}  // namespace base

--- a/src/base/net/request_cancellation_token.h
+++ b/src/base/net/request_cancellation_token.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstddef>
+
+namespace base {
+namespace net {
+
+struct RequestCancellationToken {
+  explicit RequestCancellationToken(size_t request_id);
+
+  bool operator==(const RequestCancellationToken& other) const;
+
+ private:
+  size_t request_id_;
+};
+
+}  // namespace net
+}  // namespace base

--- a/src/base/net/simple_url_loader.cc
+++ b/src/base/net/simple_url_loader.cc
@@ -7,17 +7,24 @@
 namespace base {
 namespace net {
 
-void SimpleUrlLoader::DownloadUnbounded(ResourceRequest request,
-                                        ResultCallback on_done_callback) {
-  NetThread::GetInstance().EnqueueDownload(request, std::nullopt,
-                                           std::move(on_done_callback));
+RequestCancellationToken SimpleUrlLoader::DownloadUnbounded(
+    ResourceRequest request,
+    ResultCallback on_done_callback) {
+  return NetThread::GetInstance().EnqueueDownload(request, std::nullopt,
+                                                  std::move(on_done_callback));
 }
 
-void SimpleUrlLoader::DownloadLimited(ResourceRequest request,
-                                      size_t max_response_size_bytes,
-                                      ResultCallback on_done_callback) {
-  NetThread::GetInstance().EnqueueDownload(request, max_response_size_bytes,
-                                           std::move(on_done_callback));
+RequestCancellationToken SimpleUrlLoader::DownloadLimited(
+    ResourceRequest request,
+    size_t max_response_size_bytes,
+    ResultCallback on_done_callback) {
+  return NetThread::GetInstance().EnqueueDownload(
+      request, max_response_size_bytes, std::move(on_done_callback));
+}
+
+void SimpleUrlLoader::CancelRequest(
+    RequestCancellationToken cancellation_token) {
+  return NetThread::GetInstance().CancelRequest(std::move(cancellation_token));
 }
 
 }  // namespace net

--- a/src/base/net/simple_url_loader.h
+++ b/src/base/net/simple_url_loader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "base/callback.h"
+#include "base/net/request_cancellation_token.h"
 #include "base/net/resource_request.h"
 #include "base/net/resource_response.h"
 
@@ -11,11 +12,15 @@ class SimpleUrlLoader {
  public:
   using ResultCallback = base::OnceCallback<void(ResourceResponse)>;
 
-  static void DownloadUnbounded(ResourceRequest request,
-                                ResultCallback on_done_callback);
-  static void DownloadLimited(ResourceRequest request,
-                              size_t max_response_size_bytes,
-                              ResultCallback on_done_callback);
+  static RequestCancellationToken DownloadUnbounded(
+      ResourceRequest request,
+      ResultCallback on_done_callback);
+  static RequestCancellationToken DownloadLimited(
+      ResourceRequest request,
+      size_t max_response_size_bytes,
+      ResultCallback on_done_callback);
+
+  static void CancelRequest(RequestCancellationToken cancellation_token);
 
  private:
   //


### PR DESCRIPTION
This commit adds a functionality to abort/cancel in-flight network request (on best efforts basis - asynchronously). When a network request is created, a cancellation token will be return which can be used to try to cancel the request.

Due to nature of the implementation (asynchronous), the operations is working on best-effort basis - it may be possible that request's on-done callback will still be invoked after cancellation of the request. To ensure it doesn't happen, bind callback to a weak pointer that you can invalidate when needed. As such, this is should be considered to mostly being used to avoid wasting resources on a request for which a response is no longer needed.