### PR TITLE
[#41] Implement sending POST requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,8 @@ else()
   option(LIBBASE_CLANG_TIDY "Build with clang-tidy" OFF)
 endif()
 
+option(LIBBASE_BUILD_ASAN "Build with Address Sanitizer enabled" OFF)
+
 
 #
 # Compiler setup

--- a/CMakeModules/SetupCompileFlags.cmake
+++ b/CMakeModules/SetupCompileFlags.cmake
@@ -50,15 +50,19 @@ function(SETUP_COMPILE_FLAGS)
     set(CLANG_TIDY_PROPERTIES "CXX_CLANG_TIDY;${CLANG_TIDY_EXE}")
   endif()
 
+  if(LIBBASE_BUILD_ASAN)
+    set(SANITIZE_FLAGS ";-fsanitize=address")
+  endif()
+
   if(NOT CONFIGURED_ONCE)
     set(
       LIBBASE_COMPILE_FLAGS
-      "${WARNINGS}${COVERAGE_COMPILE_FLAGS}"
+      "${WARNINGS}${COVERAGE_COMPILE_FLAGS}${SANITIZE_FLAGS}"
       CACHE STRING "Flags used by the compiler to build targets"
       FORCE)
     set(
       LIBBASE_LINK_FLAGS
-      "${COVERAGE_LINK_FLAGS}"
+      "${COVERAGE_LINK_FLAGS}${SANITIZE_FLAGS}"
       CACHE STRING "Flags used by the linker to link targets"
       FORCE)
     set(

--- a/src/base/net/resource_request.h
+++ b/src/base/net/resource_request.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -9,16 +11,18 @@ namespace base {
 namespace net {
 
 const auto kDefaultHeaders = std::vector<std::string>{};
+const auto kNoPost = std::nullopt;
 const auto kNoTimeout = base::TimeDelta{};
 
 struct ResourceRequest {
   std::string url;
   std::vector<std::string> headers = kDefaultHeaders;
+  std::optional<std::vector<uint8_t>> post_data;
+  bool headers_only = false;
 
   base::TimeDelta connect_timeout = kNoTimeout;
   base::TimeDelta timeout = kNoTimeout;
   bool follow_redirects = true;
-  bool headers_only = false;
 };
 
 }  // namespace net


### PR DESCRIPTION
This commit adds ability to send data with POST requests.

Additionally it also fixes a memory related bug introduced in PR #45 where wrong pointer was passed to CURL's WriteData function which could cause crashes.

This also adds an option to CMake to build project with ASAN enabled.