### PR TITLE
[#47] Temporarily pin CMake version to v3.31.x in GitHub Actions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Temporarily ping CMake version to 3.31 (see #47)
+      - name: Install cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.x'
+
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Temporarily ping CMake version to 3.31 (see #47)
+      - name: Install cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.x'
+
       # Setup vcpkg
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Temporarily ping CMake version to 3.31 (see #47)
+      - name: Install cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.x'
+
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:


### PR DESCRIPTION
At the moment, GitHub Actions runners switched to v4.0.0 which isn't compatible with some of the dependencies (e.g. `gflags` from VCPKG) so let's pin version to v3.31 for now.