### PR TITLE
[#41] Provide task runner to bind response callback or auto-bind to c…

### DIFF
--- a/src/base/net/impl/net_thread_impl.cc
+++ b/src/base/net/impl/net_thread_impl.cc
@@ -9,6 +9,9 @@ Result CurlCodeToNetResult(CURLcode code) {
     case CURLE_OK:
       return Result::kOk;
 
+    case CURLE_OPERATION_TIMEDOUT:
+      return Result::kTimeout;
+
     case CURLE_ABORTED_BY_CALLBACK:
       return Result::kAborted;
 
@@ -196,7 +199,8 @@ void NetThread::NetThreadImpl::EnqueueDownload_NetThread(
                      download_info.request.post_data->data());
     curl_easy_setopt(easy_handle, CURLOPT_POSTFIELDSIZE_LARGE,
                      download_info.request.post_data->size());
-  } else if (download_info.request.headers_only) {
+  }
+  if (download_info.request.headers_only) {
     curl_easy_setopt(easy_handle, CURLOPT_NOBODY, 1L);
   }
 

--- a/src/base/net/resource_request.h
+++ b/src/base/net/resource_request.h
@@ -20,8 +20,8 @@ struct ResourceRequest {
   std::optional<std::vector<uint8_t>> post_data;
   bool headers_only = false;
 
-  base::TimeDelta connect_timeout = kNoTimeout;
   base::TimeDelta timeout = kNoTimeout;
+  base::TimeDelta connect_timeout = kNoTimeout;
   bool follow_redirects = true;
 };
 

--- a/src/base/net/result.h
+++ b/src/base/net/result.h
@@ -11,6 +11,9 @@ enum class Result {
   kError,
 
   //
+  kTimeout,
+
+  //
   kAborted,
 };
 

--- a/src/base/net/simple_url_loader.cc
+++ b/src/base/net/simple_url_loader.cc
@@ -2,24 +2,44 @@
 
 #include <optional>
 
+#include "base/bind_post_task.h"
 #include "base/net/impl/net_thread.h"
 
 namespace base {
 namespace net {
 
+namespace {
+SimpleUrlLoader::ResultCallback BindOnDoneCallback(
+    SimpleUrlLoader::ResultCallback callback,
+    std::shared_ptr<TaskRunner> reply_task_runner) {
+  // TODO: Fix FROM_HERE usage here
+  if (reply_task_runner) {
+    return BindPostTask(std::move(reply_task_runner), std::move(callback),
+                        FROM_HERE);
+  }
+  return BindToCurrentSequence(std::move(callback), FROM_HERE);
+}
+}  // namespace
+
 RequestCancellationToken SimpleUrlLoader::DownloadUnbounded(
     ResourceRequest request,
-    ResultCallback on_done_callback) {
-  return NetThread::GetInstance().EnqueueDownload(request, std::nullopt,
-                                                  std::move(on_done_callback));
+    ResultCallback on_done_callback,
+    std::shared_ptr<TaskRunner> reply_task_runner) {
+  return NetThread::GetInstance().EnqueueDownload(
+      request, std::nullopt,
+      BindOnDoneCallback(std::move(on_done_callback),
+                         std::move(reply_task_runner)));
 }
 
 RequestCancellationToken SimpleUrlLoader::DownloadLimited(
     ResourceRequest request,
     size_t max_response_size_bytes,
-    ResultCallback on_done_callback) {
+    ResultCallback on_done_callback,
+    std::shared_ptr<TaskRunner> reply_task_runner) {
   return NetThread::GetInstance().EnqueueDownload(
-      request, max_response_size_bytes, std::move(on_done_callback));
+      request, max_response_size_bytes,
+      BindOnDoneCallback(std::move(on_done_callback),
+                         std::move(reply_task_runner)));
 }
 
 void SimpleUrlLoader::CancelRequest(

--- a/src/base/net/simple_url_loader.h
+++ b/src/base/net/simple_url_loader.h
@@ -4,26 +4,26 @@
 #include "base/net/request_cancellation_token.h"
 #include "base/net/resource_request.h"
 #include "base/net/resource_response.h"
+#include "base/task_runner.h"
 
 namespace base {
 namespace net {
 
 class SimpleUrlLoader {
  public:
-  using ResultCallback = base::OnceCallback<void(ResourceResponse)>;
+  using ResultCallback = OnceCallback<void(ResourceResponse)>;
 
   static RequestCancellationToken DownloadUnbounded(
       ResourceRequest request,
-      ResultCallback on_done_callback);
+      ResultCallback on_done_callback,
+      std::shared_ptr<TaskRunner> reply_task_runner = nullptr);
   static RequestCancellationToken DownloadLimited(
       ResourceRequest request,
       size_t max_response_size_bytes,
-      ResultCallback on_done_callback);
+      ResultCallback on_done_callback,
+      std::shared_ptr<TaskRunner> reply_task_runner = nullptr);
 
   static void CancelRequest(RequestCancellationToken cancellation_token);
-
- private:
-  //
 };
 
 }  // namespace net

--- a/src/base/threading/sequenced_task_runner_handle.h
+++ b/src/base/threading/sequenced_task_runner_handle.h
@@ -2,9 +2,9 @@
 
 #include <memory>
 
-namespace base {
+#include "base/sequenced_task_runner.h"
 
-class SequencedTaskRunner;
+namespace base {
 
 class SequencedTaskRunnerHandle {
  public:


### PR DESCRIPTION
…urrent

This commit adds a functionality to SimpleUrlLoader that allows user to specify on which task runner should the response for the given request (via `on_done_callback`) should be executed. If no task runner is provided it will bind it to current sequence (which is usually what users would like).

This commit also:

* added Timeout error code
* simplified networking examples with above + using built-in timeout handling instead of using guard delayed tasks
* fixed a bug where users couldn't use header-only mode with POST requests