### PR TITLE
Update README and documentation with new features and changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## `libbase` [![Language](https://img.shields.io/badge/language-C++17-blue.svg)](https://github.com/RippeR37/libbase) [![Documentation](https://img.shields.io/badge/documentation-online-blue.svg)](https://ripper37.github.io/libbase/) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/ripper37/libbase/master/LICENSE) [![GitHub Releases](https://img.shields.io/github/release/ripper37/libbase.svg)](https://github.com/ripper37/libbase/releases)
+## `libbase` [![Language](https://img.shields.io/badge/language-C++17-blue.svg)](https://github.com/RippeR37/libbase) [![Documentation](https://img.shields.io/badge/documentation-online-blue.svg)](https://ripper37.github.io/libbase/) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/ripper37/libbase/master/LICENSE) [![GitHub Releases](https://img.shields.io/github/release/ripper37/libbase.svg)](https://github.com/ripper37/libbase/releases) [![vcpkg release](https://img.shields.io/vcpkg/v/ripper37-libbase)](https://vcpkg.io/en/package/ripper37-libbase) [![vcpkg release](https://img.shields.io/vcpkg/v/ripper37-libbase?color=fba71c)](https://vcpkg.io/en/package/ripper37-libbase)
 
 | Branch | Ubuntu | Windows | MacOS | Documentation | Coverage |
 | :----: | :----: | :-----: | :---: | :-----------: | :------: |
@@ -10,9 +10,10 @@
 
 The [`libbase`](https://github.com/RippeR37/libbase/) is a small library that
 provides its users with a reimplementation of many useful low-level utilities
-known from Chromium’s
-[`//base`](https://chromium.googlesource.com/chromium/src/base/) module without
-the need to depend on the whole (or parts of the) Chromium itself.
+from Chromium’s
+[`//base`](https://chromium.googlesource.com/chromium/src/base/) module as well
+as other useful utilities (e.g. simplified networking stack based on `//net` )
+without the need to depend on the whole (or parts of the) Chromium itself.
 
 For more details with examples see the
 [documentation](https://ripper37.github.io/libbase/).
@@ -20,13 +21,30 @@ For more details with examples see the
 
 ### Building `libbase`
 
+#### Dependencies
+
+- [GLOG](https://github.com/google/glog)
+- (Optional) [GTest and GMock](https://github.com/google/googletest)
+- (Optional) [Google Benchmark](https://github.com/google/benchmark)
+
+Dependencies either have to be already installed and CMake has to be able to
+find them with `find_package()` or they can be resolved with `vcpkg`.
+
+It's recommended to use `vcpkg` to resolve all dependencies. To do so, make sure
+to export `VCPKG_ROOT` environment variable before configuring the CMake
+project:
+
+```bash
+export VCPKG_ROOT=/path/to/vcpkg/root/
+```
+
 #### Building with CMake
 
 ```bash
 git clone https://github.com/RippeR37/libbase.git
 cd libbase
 cmake -S . -B build
-cmake --build build
+cmake --build build [-j <parallel_jobs>] [--config <Release|Debug>]
 ```
 
 #### Running unit tests
@@ -35,12 +53,61 @@ cmake --build build
 ctest --test-dir build
 ```
 
-#### Using `libbase` in your project
+### Using `libbase` in your project
 
-For an example of how to use `libbase` in your project refer to the
+You can add `libbase` to your project by either building and installing all
+required dependencies and the library itself, or using `vcpkg` to do that for
+you. It's recommended to use `vcpkg`.
+
+#### With `vcpkg`
+
+You can install `libbase` in _classic mode_ with:
+
+```bash
+vcpkg install ripper37-libbase
+```
+
+or (recommended) in _manifest mode_ by adding to your project's `vcpkg.json`
+file this library as a dependency:
+
+```jsonc
+{
+  "name": "your-project",
+  // ...
+  "dependencies": [
+    // ...
+    "ripper37-libbase"
+  ]
+}
+```
+
+#### Manual
+
+Refer to the
+[building section above](https://github.com/RippeR37/libbase?tab=readme-ov-file#building-libbase)
+on how to build the library and dependencies. Once built, make sure to install
+them with
+
+```bash
+cmake --install build [--prefix <install_path_prefix>]
+```
+
+#### Add to your CMake project
+
+Once `libbase` is installed in your system, simply add it and link it to be able
+to use it:
+
+```cmake
+find_package(libbase CONFIG REQUIRED)
+target_link_libraries(your_target PRIVATE libbase::libbase)
+```
+
+For more details please refer to the
 [documentation](https://ripper37.github.io/libbase/master/getting_started/using.html)
 or check out the
 [CMake-based example project](https://github.com/RippeR37/libbase-example-cmake).
+
+### Support
 
 #### Requirements
 
@@ -59,18 +126,6 @@ or check out the
 * Clang (13 through 18)
 * MSVC (2022 19.43)
 
-#### Dependencies
-
-- [GLOG](https://github.com/google/glog)
-- (Optional) [GTest and GMock](https://github.com/google/googletest)
-- (Optional) [Google Benchmark](https://github.com/google/benchmark)
-
-Dependencies either have to be already installed and CMake has to be able to
-find them with `find_package()` or they can be resolved with VCPKG.
-
-If you wish for CMake to use VCPKG to resolve dependencies you have to set
-`VCPKG_ROOT` environment variable before configuring the project.
-
-#### License
+### License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'libbase'
-copyright = '2022, Damian Dyńdo'
+copyright = '2025, Damian Dyńdo'
 author = 'Damian Dyńdo'
 
 # Breathe extension

--- a/docs/features/threads.rst
+++ b/docs/features/threads.rst
@@ -636,6 +636,43 @@ waitable event will be signalled from a different thread.
    documentation page.
 
 
+Run Loop
+-------------------
+
+In certain cases, you may find yourself running code on a thread that is not
+associated with a task runner/message loop. One such case might be the main
+application thread. In such cases, you can still enable using all functionality
+of task runners/sequences on that thread with :class:`base::RunLoop` object.
+Once created, it creates a message loop and task runner and configures global
+state for that thread to associate it with them. As long as this object will be
+alive, you will be able to use task runner associated with it and post tasks
+between that thread and other threads/sequences.
+
+.. admonition:: Example - :class:`base::RunLoop`
+   :class: admonition-example-code
+
+   .. code-block:: cpp
+
+      int main(int argc, char* argv[]) {
+        base::RunLoop run_loop;
+
+        run_loop.TaskRunner()->PostDelayedTask(FROM_HERE, run_loop.QuitClosure(),
+                                              base::Seconds(1));
+
+        // This will block current thread until the quit closure is executed
+        run_loop.Run();
+      }
+
+.. warning::
+
+   Current implementation does NOT allow nesting of message loops, so you can't
+   create :class:`base::RunLoop` within a task executed on ``libbase`` thread
+   that already is associated with message loop.
+
+   Furthermore, once quit, you cannot queue or run any more tasks with that
+   :class:`base::RunLoop` instance.
+
+
 .. Aliases
 
 .. |OnceCB| replace:: :cpp:class:`base::OnceCallback\<...> \

--- a/docs/getting_started/using.rst
+++ b/docs/getting_started/using.rst
@@ -49,19 +49,24 @@ existing project, please skip :ref:`here <skip_existing_project>`.
    .. _skip_existing_project:
 
 
-#. Initialize vcpkg and add ``libbase`` library as a dependency
+#. Initialize ``vcpkg`` and add ``libbase`` library as a dependency
+
+   .. important::
+
+      To avoid name clashes with other libraries, the ``vcpkg`` port for this
+      library is called ``ripper37-libbase``. This is the name you should use
+      when adding it to your project.
 
    .. code-block:: console
 
       $ vcpkg new --application
-      $ vcpkg add port libbase
+      $ vcpkg add port ripper37-libbase
 
    .. note::
 
       You can customize which parts of ``libbase`` you want to use by specifying
-      which features you want to enable. It is also recommended to disable not
-      needed default features (examples and tests) by modifying the dependency
-      in the ``vcpkg.json`` file to look like:
+      which features you want to enable. To do that, you need to modify the
+      dependency entry in the ``vcpkg.json`` file to look like:
 
       .. code-block:: json
          :caption: vcpkg.json
@@ -70,10 +75,10 @@ existing project, please skip :ref:`here <skip_existing_project>`.
            "dependencies": [
              // ...
              {
-               "name": "libbase",
+               "name": "ripper37-libbase",
                "default-features": false,
                "dependencies": [
-                 // list features that you need
+                 // list features that you need here
                ]
              },
              // ...

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -19,12 +19,6 @@
       "features": [
         "customprefix"
       ]
-    },
-    {
-      "name": "curl",
-      "features": [
-        "ssl"
-      ]
     }
   ],
   "features": {
@@ -42,11 +36,23 @@
       "dependencies": [
         "benchmark"
       ]
+    },
+    "net": {
+      "description": "Build net module",
+      "dependencies": [
+        {
+          "name": "curl",
+          "features": [
+            "ssl"
+          ]
+        }
+      ]
     }
   },
   "default-features": [
     "examples",
     "unittests",
-    "perftests"
+    "perftests",
+    "net"
   ]
 }


### PR DESCRIPTION
This commit updates the README and project documentation to reflect new features introduced in the latest commits as well as some changes.

It also updates the information about building and installing the project with `vcpkg` and fixes the `vcpkg` port name to be used:

  `ripper37-libbase`

Additionally it adds a vcpkg shield/badge in README to advertise library availability in that package manager.