### PR TITLE
[#41] Make net module optional and separate target (`libbase::libbase_net`)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules")
 #
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  option(LIBBASE_BUILD_MODULE_NET "Build networking module." ON)
+
   option(LIBBASE_BUILD_EXAMPLES "Build examples." ON)
   option(LIBBASE_BUILD_TESTS "Build unit tests." ON)
   option(LIBBASE_CODE_COVERAGE "Compute code coverage." OFF)
@@ -38,6 +40,8 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   option(LIBBASE_BUILD_DOCS "Build documentation." OFF)
   option(LIBBASE_CLANG_TIDY "Build with clang-tidy" ON)
 else()
+  option(LIBBASE_BUILD_MODULE_NET "Build networking module." ON)
+
   option(LIBBASE_BUILD_EXAMPLES "Build examples." OFF)
   option(LIBBASE_BUILD_TESTS "Build unit tests." OFF)
   option(LIBBASE_CODE_COVERAGE "Compute code coverage." OFF)
@@ -78,8 +82,6 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 find_package(Threads REQUIRED)
 # GLOG
 find_package(glog CONFIG REQUIRED)
-# curl
-find_package(CURL CONFIG REQUIRED)
 
 
 #
@@ -112,8 +114,13 @@ endif()
 # Installation
 #
 
+set(LIBBASE_INSTALL_TARGETS libbase)
+if(LIBBASE_BUILD_MODULE_NET)
+  list(APPEND LIBBASE_INSTALL_TARGETS libbase_net)
+endif()
+
 # Install the library
-install(TARGETS libbase
+install(TARGETS ${LIBBASE_INSTALL_TARGETS}
         EXPORT libbase_targets
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -139,6 +146,7 @@ install(EXPORT libbase_targets
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
 "include(CMakeFindDependencyMacro)\n"
 "find_dependency(glog)\n"
+"find_package(curl)\n"
 "find_package(GTest)\n"
 "find_package(benchmark)\n"
 "include(\"\${CMAKE_CURRENT_LIST_DIR}/${CMAKE_PROJECT_NAME}-targets.cmake\")\n"

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,7 +1,12 @@
 add_executable(simple "")
 
 target_compile_options(simple PRIVATE ${LIBBASE_COMPILE_FLAGS})
-target_link_libraries(simple PRIVATE libbase)
+
+if(LIBBASE_BUILD_MODULE_NET)
+  target_link_libraries(simple PRIVATE libbase libbase_net)
+else()
+  target_link_libraries(simple PRIVATE libbase)
+endif()
 
 target_sources(simple
   PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,8 +32,7 @@ target_include_directories(libbase PUBLIC
 target_link_libraries(libbase PUBLIC
   ${LIBBASE_LINK_FLAGS}
   Threads::Threads
-  glog::glog
-  CURL::libcurl)
+  glog::glog)
 
 target_sources(libbase
   PRIVATE
@@ -63,17 +62,6 @@ target_sources(libbase
     base/message_loop/message_pump.h
     base/message_loop/run_loop.cc
     base/message_loop/run_loop.h
-    base/net/impl/net_thread_impl.cc
-    base/net/impl/net_thread_impl.h
-    base/net/impl/net_thread.cc
-    base/net/impl/net_thread.h
-    base/net/request_cancellation_token.cc
-    base/net/request_cancellation_token.h
-    base/net/resource_request.h
-    base/net/resource_response.h
-    base/net/result.h
-    base/net/simple_url_loader.cc
-    base/net/simple_url_loader.h
     base/sequence_checker.cc
     base/sequence_checker.h
     base/sequence_id.cc
@@ -129,3 +117,54 @@ target_sources(libbase
     base/type_traits.h
     base/vlog_is_on.h
 )
+
+#
+# Library module - net
+#
+
+if(LIBBASE_BUILD_MODULE_NET)
+  find_package(CURL CONFIG REQUIRED)
+
+  add_library(libbase_net STATIC "")
+
+  target_compile_features(libbase_net PUBLIC cxx_std_17)
+  target_compile_options(libbase_net PRIVATE ${LIBBASE_COMPILE_FLAGS})
+  target_compile_definitions(libbase_net PUBLIC
+    ${LIBBASE_DEFINES}
+    ${LIBBASE_FEATURE_DEFINES})
+  target_compile_definitions(libbase_net
+      INTERFACE LIBBASE_MODULE_NET
+  )
+  set_target_properties(libbase_net PROPERTIES
+    CXX_EXTENSIONS ON
+    ${LIBBASE_OPT_CLANG_TIDY_PROPERTIES})
+
+  target_include_directories(libbase_net PUBLIC
+      $<BUILD_INTERFACE:${libbase_SOURCE_DIR}/src/>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libbase>
+  )
+
+  target_link_libraries(libbase_net PUBLIC
+    ${LIBBASE_LINK_FLAGS}
+    libbase
+    Threads::Threads
+    glog::glog
+    CURL::libcurl)
+
+  target_sources(libbase_net
+    PRIVATE
+      base/net/impl/net_thread_impl.cc
+      base/net/impl/net_thread_impl.h
+      base/net/impl/net_thread.cc
+      base/net/impl/net_thread.h
+      base/net/init.cc
+      base/net/init.h
+      base/net/request_cancellation_token.cc
+      base/net/request_cancellation_token.h
+      base/net/resource_request.h
+      base/net/resource_response.h
+      base/net/result.h
+      base/net/simple_url_loader.cc
+      base/net/simple_url_loader.h
+  )
+endif()

--- a/src/base/init.cc
+++ b/src/base/init.cc
@@ -1,7 +1,6 @@
 #include "base/init.h"
 
 #include "base/logging.h"
-#include "base/net/impl/net_thread.h"
 
 namespace base {
 
@@ -18,11 +17,6 @@ void Initialize(int /*argc*/, char* argv[], InitOptions options) {
   google::InitGoogleLogging(argv[0]);
   google::InstallPrefixFormatter(&detail::LogFormatter);
   google::InstallFailureSignalHandler();
-
-  if (g_init_options.InitializeNetworking) {
-    // Initialize Networking thread
-    net::NetThread::GetInstance().Start();
-  }
 }
 
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
@@ -33,19 +27,9 @@ void InitializeForTests(int /*argc*/, char* argv[], InitOptions options) {
 
   google::InitGoogleLogging(argv[0]);
   google::InstallPrefixFormatter(&detail::LogFormatter);
-
-  if (g_init_options.InitializeNetworking) {
-    // Initialize Networking thread
-    net::NetThread::GetInstance().Start();
-  }
 }
 
 void Deinitialize() {
-  if (g_init_options.InitializeNetworking) {
-    // Deinitialize Networking thread
-    net::NetThread::GetInstance().Stop();
-  }
-
   google::ShutdownGoogleLogging();
 }
 

--- a/src/base/init.h
+++ b/src/base/init.h
@@ -5,9 +5,6 @@ namespace base {
 struct InitOptions {
   // Logging
   bool LogToStderr = true;
-
-  // Networking
-  bool InitializeNetworking = false;
 };
 
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)

--- a/src/base/net/init.cc
+++ b/src/base/net/init.cc
@@ -1,0 +1,23 @@
+#include "base/net/init.h"
+
+#include "base/net/impl/net_thread.h"
+
+namespace base {
+namespace net {
+
+namespace {
+InitOptions g_net_init_options;
+}
+
+void Initialize(InitOptions options) {
+  g_net_init_options = options;
+
+  net::NetThread::GetInstance().Start();
+}
+
+void Deinitialize() {
+  net::NetThread::GetInstance().Stop();
+}
+
+}  // namespace net
+}  // namespace base

--- a/src/base/net/init.h
+++ b/src/base/net/init.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace base {
+namespace net {
+
+struct InitOptions {};
+
+void Initialize(InitOptions options);
+void Deinitialize();
+
+}  // namespace net
+}  // namespace base


### PR DESCRIPTION
This commit changes the structure of the `net` module so that it can be made optional. New build option is introduced to allow specifying whether to build and use the new `net` module or not:

    LIBBASE_BUILD_MODULE_NET

Additionaly, minor changes to initialization logic were made - now users have to initialize separate modules independently. Furthermore the simple example has been updated to work correctly regardless of whether the `net` module is built or not by using conditional linking and newly introduced compiler definition for library users: `LIBBASE_MODULE_NET`.

This will be made as separate feature (probably enabled by default) for vcpkg users, that can be disabled to avoid pulling in `libcurl`.