### PR TITLE
[#39][wx] Add wxWidgets integration with example application

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.compiler.name }} ${{ matrix.build_type }} (${{ matrix.os }})
+    name: ${{ matrix.compiler.name }} ${{ matrix.build_type }} (${{ matrix.os }}) ${{ matrix.name_suffix }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -27,6 +27,7 @@ jobs:
           # Optional module builds
           - os: macos-latest
             build_type: Release
+            name_suffix: "(wxWidget integration)"
             compiler: {name: Clang, cc: clang, cxx: clang++}
             cmake_args: "-DLIBBASE_BUILD_MODULE_WX=ON"
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,8 @@ jobs:
         compiler: [
           {name: Clang, cc: clang, cxx: clang++, package: true}
         ]
+        name_suffix: [""]
+        cmake_args: [""]
         include:
           # Optional module builds
           - os: macos-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,12 @@ jobs:
         compiler: [
           {name: Clang, cc: clang, cxx: clang++, package: true}
         ]
+        include:
+          # Optional module builds
+          - os: macos-latest
+            build_type: Release
+            compiler: {name: Clang, cc: clang, cxx: clang++}
+            cmake_args: "-DLIBBASE_BUILD_MODULE_WX=ON"
 
     env:
       CC: ${{ matrix.compiler.cc }}
@@ -45,7 +51,7 @@ jobs:
           vcpkgGitCommitId: '782ccc18d8b819cdef6794a6c03eb3d9f7cd04aa'
 
       - name: CMake configuration
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_args }} -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       - name: Building
         run: cmake --build build --config ${{ matrix.build_type }} -j 8
       - name: Testing

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -53,7 +53,7 @@ jobs:
           - os_compiler: {os: ubuntu-24.04, name: Clang 18 (wxWidget integration), cc: clang-18, cxx: clang++-18, tidy: clang-tidy-18 }
             build_type: Release
             cmake_args: "-DLIBBASE_BUILD_MODULE_WX=ON"
-            package_deps: "autoconf automake libtool pkg-config libx11-dev libxft-dev libxext-dev libxi-dev libxtst-dev bison gperf libxinerama-dev libxdamage-dev libxcursor-dev libxi-dev libxrandr-dev libgles2-mesa-dev"
+            package_deps: "autoconf automake libtool pkg-config libx11-dev libxft-dev libxext-dev libxi-dev libxtst-dev libltdl-dev bison gperf libxinerama-dev libxdamage-dev libxcursor-dev libxi-dev libxrandr-dev libgles2-mesa-dev"
 
           # ASAN/TSAN builds
           - os_compiler: {os: ubuntu-24.04, name: Clang 18 (ASAN), cc: clang-18, cxx: clang++-18, tidy: clang-tidy-18 }

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,6 +49,11 @@ jobs:
           {os: ubuntu-24.04, name: Clang 18, cc: clang-18, cxx: clang++-18, tidy: clang-tidy-18, package: true},
         ]
         include:
+          # Optional module builds
+          - os_compiler: {os: ubuntu-24.04, name: Clang 18 (wxWidget integration), cc: clang-18, cxx: clang++-18, tidy: clang-tidy-18 }
+            build_type: Release
+            cmake_args: "-DLIBBASE_BUILD_MODULE_WX=ON"
+
           # ASAN/TSAN builds
           - os_compiler: {os: ubuntu-24.04, name: Clang 18 (ASAN), cc: clang-18, cxx: clang++-18, tidy: clang-tidy-18 }
             build_type: Debug

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -53,6 +53,7 @@ jobs:
           - os_compiler: {os: ubuntu-24.04, name: Clang 18 (wxWidget integration), cc: clang-18, cxx: clang++-18, tidy: clang-tidy-18 }
             build_type: Release
             cmake_args: "-DLIBBASE_BUILD_MODULE_WX=ON"
+            package_deps: "autoconf automake libtool pkg-config libx11-dev libxft-dev libxext-dev libxi-dev libxtst-dev bison gperf libxinerama-dev libxdamage-dev libxcursor-dev libxi-dev libxrandr-dev libgles2-mesa-dev"
 
           # ASAN/TSAN builds
           - os_compiler: {os: ubuntu-24.04, name: Clang 18 (ASAN), cc: clang-18, cxx: clang++-18, tidy: clang-tidy-18 }
@@ -103,6 +104,9 @@ jobs:
           then
             sudo apt install ${{ matrix.os_compiler.cc }} ${{ matrix.os_compiler.cxx }}
           fi
+      - name: (Optional) System packages
+        if: ${{ matrix.package_deps }}
+        run: sudo apt install ${{ matrix.package_deps }}
       - name: (Optional) Clang-tidy installation
         if: ${{ startsWith(matrix.os_compiler.cc, 'clang') }}
         run: if ! command -v ${{ matrix.os_compiler.tidy }} &> /dev/null; then sudo apt install ${{ matrix.os_compiler.tidy }}; fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    name: MSVC ${{ matrix.build_type }} (${{ matrix.os }})
+    name: MSVC ${{ matrix.build_type }} (${{ matrix.os }}) ${{ matrix.name_suffix }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -24,6 +24,7 @@ jobs:
           # Optional module builds
           - os: windows-latest
             build_type: Release
+            name_suffix: "(wxWidget integration)"
             cmake_args: "-DLIBBASE_BUILD_MODULE_WX=ON"
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,11 @@ jobs:
       matrix:
         os: [windows-2022, windows-latest]
         build_type: [Release, Debug]
+        include:
+          # Optional module builds
+          - os: windows-latest
+            build_type: Release
+            cmake_args: "-DLIBBASE_BUILD_MODULE_WX=ON"
 
     steps:
       - name: Checkout repository
@@ -38,7 +43,7 @@ jobs:
           vcpkgGitCommitId: '782ccc18d8b819cdef6794a6c03eb3d9f7cd04aa'
 
       - name: CMake configuration
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_args }} -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       - name: Building
         run: cmake --build build --config ${{ matrix.build_type }} -j 8
       - name: Testing

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,8 @@ jobs:
       matrix:
         os: [windows-2022, windows-latest]
         build_type: [Release, Debug]
+        name_suffix: [""]
+        cmake_args: [""]
         include:
           # Optional module builds
           - os: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,27 +31,31 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules")
 #
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-  option(LIBBASE_BUILD_MODULE_NET "Build networking module." ON)
-
   option(LIBBASE_BUILD_EXAMPLES "Build examples." ON)
   option(LIBBASE_BUILD_TESTS "Build unit tests." ON)
-  option(LIBBASE_CODE_COVERAGE "Compute code coverage." OFF)
   option(LIBBASE_BUILD_PERFORMANCE_TESTS "Build performance tests." ON)
-  option(LIBBASE_BUILD_DOCS "Build documentation." OFF)
   option(LIBBASE_CLANG_TIDY "Build with clang-tidy" ON)
 else()
-  option(LIBBASE_BUILD_MODULE_NET "Build networking module." ON)
-
   option(LIBBASE_BUILD_EXAMPLES "Build examples." OFF)
   option(LIBBASE_BUILD_TESTS "Build unit tests." OFF)
-  option(LIBBASE_CODE_COVERAGE "Compute code coverage." OFF)
   option(LIBBASE_BUILDPERFORMANCE_TESTS "Build performance tests." OFF)
-  option(LIBBASE_BUILD_DOCS "Build documentation." OFF)
   option(LIBBASE_CLANG_TIDY "Build with clang-tidy" OFF)
 endif()
 
+option(LIBBASE_CODE_COVERAGE "Compute code coverage." OFF)
+option(LIBBASE_BUILD_DOCS "Build documentation." OFF)
 option(LIBBASE_BUILD_ASAN "Build with Address Sanitizer enabled" OFF)
 option(LIBBASE_BUILD_TSAN "Build with Thread Sanitizer enabled" OFF)
+
+#
+# Modules
+#
+
+# Core modules
+option(LIBBASE_BUILD_MODULE_NET "Build networking module." ON)
+
+# Optional modules
+option(LIBBASE_BUILD_MODULE_WX "Build wxWidgets integration module." OFF)
 
 
 #
@@ -118,6 +122,9 @@ set(LIBBASE_INSTALL_TARGETS libbase)
 if(LIBBASE_BUILD_MODULE_NET)
   list(APPEND LIBBASE_INSTALL_TARGETS libbase_net)
 endif()
+if(LIBBASE_BUILD_MODULE_WX)
+  list(APPEND LIBBASE_INSTALL_TARGETS libbase_wx)
+endif()
 
 # Install the library
 install(TARGETS ${LIBBASE_INSTALL_TARGETS}
@@ -147,6 +154,7 @@ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
 "include(CMakeFindDependencyMacro)\n"
 "find_dependency(glog)\n"
 "find_package(curl)\n"
+"find_package(wxWidgets)\n"
 "find_package(GTest)\n"
 "find_package(benchmark)\n"
 "include(\"\${CMAKE_CURRENT_LIST_DIR}/${CMAKE_PROJECT_NAME}-targets.cmake\")\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
 #
-# Build options
-#
-
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-  option(LIBBASE_BUILD_EXAMPLES "Build examples." ON)
-  option(LIBBASE_BUILD_TESTS "Build unit tests." ON)
-  option(LIBBASE_BUILD_PERFORMANCE_TESTS "Build performance tests." ON)
-  option(LIBBASE_CLANG_TIDY "Build with clang-tidy" ON)
-else()
-  option(LIBBASE_BUILD_EXAMPLES "Build examples." OFF)
-  option(LIBBASE_BUILD_TESTS "Build unit tests." OFF)
-  option(LIBBASE_BUILDPERFORMANCE_TESTS "Build performance tests." OFF)
-  option(LIBBASE_CLANG_TIDY "Build with clang-tidy" OFF)
-endif()
-
-option(LIBBASE_CODE_COVERAGE "Compute code coverage." OFF)
-option(LIBBASE_BUILD_DOCS "Build documentation." OFF)
-option(LIBBASE_BUILD_ASAN "Build with Address Sanitizer enabled" OFF)
-option(LIBBASE_BUILD_TSAN "Build with Thread Sanitizer enabled" OFF)
-
-#
 # Modules
 #
 
@@ -59,6 +38,28 @@ project(libbase
 
 include(GNUInstallDirs)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules")
+
+
+#
+# Build options
+#
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  option(LIBBASE_BUILD_EXAMPLES "Build examples." ON)
+  option(LIBBASE_BUILD_TESTS "Build unit tests." ON)
+  option(LIBBASE_BUILD_PERFORMANCE_TESTS "Build performance tests." ON)
+  option(LIBBASE_CLANG_TIDY "Build with clang-tidy" ON)
+else()
+  option(LIBBASE_BUILD_EXAMPLES "Build examples." OFF)
+  option(LIBBASE_BUILD_TESTS "Build unit tests." OFF)
+  option(LIBBASE_BUILDPERFORMANCE_TESTS "Build performance tests." OFF)
+  option(LIBBASE_CLANG_TIDY "Build with clang-tidy" OFF)
+endif()
+
+option(LIBBASE_CODE_COVERAGE "Compute code coverage." OFF)
+option(LIBBASE_BUILD_DOCS "Build documentation." OFF)
+option(LIBBASE_BUILD_ASAN "Build with Address Sanitizer enabled" OFF)
+option(LIBBASE_BUILD_TSAN "Build with Thread Sanitizer enabled" OFF)
 
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
 #
-# Dependency resolution
-#
-
-option(LIBBASE_DEPENDENCIES_USE_VCPKG "Fetch dependencies with VCPKG" ON)
-
-if (LIBBASE_DEPENDENCIES_USE_VCPKG)
-  if(DEFINED ENV{VCPKG_ROOT})
-    set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
-  else()
-    message(WARNING "Requested to use VCPKG for dependency resolution but VCPKG_ROOT environment variable is not set, ignoring")
-  endif()
-endif()
-
-
-#
-# Project setup
-#
-
-project(libbase
-        VERSION 1.0.1
-        LANGUAGES CXX)
-
-include(GNUInstallDirs)
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules")
-
-#
 # Build options
 #
 
@@ -53,9 +27,38 @@ option(LIBBASE_BUILD_TSAN "Build with Thread Sanitizer enabled" OFF)
 
 # Core modules
 option(LIBBASE_BUILD_MODULE_NET "Build networking module." ON)
-
 # Optional modules
 option(LIBBASE_BUILD_MODULE_WX "Build wxWidgets integration module." OFF)
+
+
+#
+# Dependency resolution & features
+#
+
+if(DEFINED ENV{VCPKG_ROOT})
+  set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+endif()
+
+if(CMAKE_TOOLCHAIN_FILE)
+  string(REGEX MATCH "vcpkg\\.cmake$" IS_VCPKG "${CMAKE_TOOLCHAIN_FILE}")
+  if(IS_VCPKG)
+    if(LIBBASE_BUILD_MODULE_WX)
+      list(APPEND VCPKG_MANIFEST_FEATURES "wx")
+    endif()
+  endif()
+endif()
+
+
+#
+# Project setup
+#
+
+project(libbase
+        VERSION 1.0.1
+        LANGUAGES CXX)
+
+include(GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules")
 
 
 #

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -13,15 +13,24 @@ CMake options affect what targets are build and how. They have two defaults:
 * Internal - used when the ``libbase`` is built as the main project,
 * External - used when the ``libbase`` is built as part of another project.
 
+.. _configuration-libbase-modules:
+
+.. option:: LIBBASE_BUILD_MODULE_NET=<ON|OFF>
+
+   Build networking module (``libbase_net`` target, requires ``libcurl``).
+
+   :Default (internal): ON
+   :Default (external): ON
+
+.. option:: LIBBASE_BUILD_MODULE_WX=<ON|OFF>
+
+   Build wxWidgets integration module (``libbase_wx`` target, requires
+   ``wxWidgets``).
+
+   :Default (internal): OFF
+   :Default (external): OFF
+
 .. _configuration-libbase-build-examples:
-
-.. option:: LIBBASE_DEPENDENCIES_USE_VCPKG=<ON|OFF>
-
-   Controls whether CMake should resolve dependencies through installed
-   ``vcpkg`` package manager or expect them to be already installed in the
-   system. If enabled, ensure ``VCPKG_ROOT`` environment variable is set.
-
-   :Default: ON
 
 .. option:: LIBBASE_BUILD_EXAMPLES=<ON|OFF>
 
@@ -69,6 +78,22 @@ CMake options affect what targets are build and how. They have two defaults:
 .. option:: LIBBASE_CLANG_TIDY=<ON|OFF>
 
    Build library with clang-tidy.
+
+   :Default (internal): ON
+   :Default (external): OFF
+
+.. option:: LIBBASE_BUILD_ASAN=<ON|OFF>
+
+   Build project with Address Sanitizer enabled. Must not be used together with
+   Thread Sanitizer.
+
+   :Default (internal): OFF
+   :Default (external): OFF
+
+.. option:: LIBBASE_BUILD_TSAN=<ON|OFF>
+
+   Build project with Thread Sanitizer enabled. Must not be used together with
+   Address Sanitizer.
 
    :Default (internal): ON
    :Default (external): OFF

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,1 +1,5 @@
 add_subdirectory(simple)
+
+if(LIBBASE_BUILD_MODULE_WX)
+  add_subdirectory(wxwidgets_integration)
+endif()

--- a/examples/wxwidgets_integration/CMakeLists.txt
+++ b/examples/wxwidgets_integration/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(wxwidgets_integration_example WIN32 "")
+
+target_compile_options(wxwidgets_integration_example PRIVATE ${LIBBASE_COMPILE_FLAGS})
+
+target_link_libraries(wxwidgets_integration_example PRIVATE
+    libbase
+    libbase_wx)
+
+target_sources(wxwidgets_integration_example
+  PRIVATE
+    app.cc
+    app.h
+    main_frame.cc
+    main_frame.h
+    main.cc
+)

--- a/examples/wxwidgets_integration/app.cc
+++ b/examples/wxwidgets_integration/app.cc
@@ -1,0 +1,18 @@
+#include "app.h"
+#include "main_frame.h"
+
+bool IntegrationExample::OnInit() {
+  message_loop_attachment_ =
+      std::make_unique<base::wx::WxMessageLoopAttachment>(this);
+  worker_thread_.Start();
+
+  auto* frame = new MainFrame(worker_thread_.TaskRunner());
+  frame->Show(true);
+  return true;
+}
+
+int IntegrationExample::OnExit() {
+  worker_thread_.Stop();
+  message_loop_attachment_.reset();
+  return 0;
+}

--- a/examples/wxwidgets_integration/app.h
+++ b/examples/wxwidgets_integration/app.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <memory>
+
+#include "base/message_loop/wx/wx_message_loop_attachment.h"
+#include "base/threading/thread.h"
+
+#include "wx/app.h"
+
+class IntegrationExample : public wxApp {
+ public:
+  bool OnInit() override;
+  int OnExit() override;
+
+ private:
+  std::unique_ptr<base::wx::WxMessageLoopAttachment> message_loop_attachment_;
+  base::Thread worker_thread_;
+};

--- a/examples/wxwidgets_integration/main.cc
+++ b/examples/wxwidgets_integration/main.cc
@@ -1,0 +1,5 @@
+#include "app.h"
+
+#include "wx/app.h"
+
+wxIMPLEMENT_APP(IntegrationExample);

--- a/examples/wxwidgets_integration/main_frame.cc
+++ b/examples/wxwidgets_integration/main_frame.cc
@@ -1,0 +1,37 @@
+#include "main_frame.h"
+
+#include "wx/msgdlg.h"
+#include "wx/panel.h"
+
+MainFrame::MainFrame(std::shared_ptr<base::SequencedTaskRunner> task_runner)
+    : wxFrame(nullptr,
+              wxID_ANY,
+              "wxWidgets integration example",
+              wxDefaultPosition,
+              wxSize(400, 200)),
+      task_runner_(std::move(task_runner)),
+      weak_factory_(this) {
+  weak_this_ = weak_factory_.GetWeakPtr();
+
+  auto* panel = new wxPanel(this, wxID_ANY);
+  m_button = new wxButton(panel, wxID_ANY, "Click Me", wxPoint(150, 70),
+                          wxDefaultSize);
+
+  m_button->Bind(wxEVT_BUTTON, &MainFrame::OnButtonClicked, this);
+}
+
+void MainFrame::OnButtonClicked(wxCommandEvent&) {
+  DCHECK(!task_runner_->RunsTasksInCurrentSequence());
+
+  task_runner_->PostTaskAndReply(
+      FROM_HERE, base::BindOnce([]() {
+        // some work on worker thread
+      }),
+      base::BindOnce(&MainFrame::ShowMessageBox, weak_this_));
+}
+
+void MainFrame::ShowMessageBox() {
+  DCHECK(!task_runner_->RunsTasksInCurrentSequence());
+
+  wxMessageBox("Hello world!", "Message", wxOK | wxICON_INFORMATION);
+}

--- a/examples/wxwidgets_integration/main_frame.h
+++ b/examples/wxwidgets_integration/main_frame.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+
+#include "base/sequenced_task_runner.h"
+#include "base/synchronization/waitable_event.h"
+
+#include "wx/button.h"
+#include "wx/frame.h"
+
+class MainFrame : public wxFrame {
+ public:
+  MainFrame(std::shared_ptr<base::SequencedTaskRunner> task_runner);
+
+ private:
+  void OnButtonClicked(wxCommandEvent& event);
+  void ShowMessageBox();
+
+  std::shared_ptr<base::SequencedTaskRunner> task_runner_;
+  wxButton* m_button;
+
+  base::WeakPtr<MainFrame> weak_this_;
+  base::WeakPtrFactory<MainFrame> weak_factory_{this};
+};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -168,3 +168,45 @@ if(LIBBASE_BUILD_MODULE_NET)
       base/net/simple_url_loader.h
   )
 endif()
+
+
+#
+# Library integration module - wx (wxWidgets)
+#
+
+if(LIBBASE_BUILD_MODULE_WX)
+  find_package(wxWidgets CONFIG REQUIRED)
+
+  add_library(libbase_wx STATIC "")
+
+  target_compile_features(libbase_wx PUBLIC cxx_std_17)
+  target_compile_options(libbase_wx PRIVATE ${LIBBASE_COMPILE_FLAGS})
+  target_compile_definitions(libbase_wx PUBLIC
+    ${LIBBASE_DEFINES}
+    ${LIBBASE_FEATURE_DEFINES})
+  target_compile_definitions(libbase_wx
+      INTERFACE LIBBASE_MODULE_WX
+  )
+  set_target_properties(libbase_wx PROPERTIES
+    CXX_EXTENSIONS ON
+    ${LIBBASE_OPT_CLANG_TIDY_PROPERTIES})
+
+  target_include_directories(libbase_wx PUBLIC
+      $<BUILD_INTERFACE:${libbase_SOURCE_DIR}/src/>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libbase>
+  )
+
+  target_link_libraries(libbase_wx PUBLIC
+    ${LIBBASE_LINK_FLAGS}
+    libbase
+    Threads::Threads
+    glog::glog
+    wx::core
+    wx::base)
+
+  target_sources(libbase_wx
+    PRIVATE
+      base/message_loop/wx/wx_message_loop_attachment.cc
+      base/message_loop/wx/wx_message_loop_attachment.h
+  )
+endif()

--- a/src/base/message_loop/wx/wx_message_loop_attachment.cc
+++ b/src/base/message_loop/wx/wx_message_loop_attachment.cc
@@ -1,0 +1,131 @@
+#include "base/message_loop/wx/wx_message_loop_attachment.h"
+
+#include <atomic>
+
+#include "base/threading/delayed_task_manager_shared_instance.h"
+#include "base/threading/task_runner_impl.h"
+
+#include "wx/event.h"
+
+namespace base {
+namespace wx {
+
+namespace detail {
+
+//
+// WxExecuteTaskEvent
+//
+
+class WxExecuteTaskEvent;
+wxDECLARE_EVENT(wxEVT_LIBBASE_EXECUTE_TASK, WxExecuteTaskEvent);
+
+class WxExecuteTaskEvent : public wxCommandEvent {
+ public:
+  WxExecuteTaskEvent(std::shared_ptr<MessagePump::PendingTask> pending_task,
+                     wxEventType eventType = wxEVT_LIBBASE_EXECUTE_TASK)
+      : wxCommandEvent(eventType), pending_task_(std::move(pending_task)) {}
+
+  WxExecuteTaskEvent(const WxExecuteTaskEvent& other)
+      : WxExecuteTaskEvent(other.pending_task_, other.GetEventType()) {}
+
+  wxEvent* Clone() const override { return new WxExecuteTaskEvent(*this); }
+
+  std::shared_ptr<MessagePump::PendingTask> pending_task_;
+};
+
+using MyWxExecuteTaskEventFunction =
+    void (wxEvtHandler::*)(WxExecuteTaskEvent&);
+#define MyWxExecuteTaskEventHandler(func) \
+  wxEVENT_HANDLER_CAST(MyWxExecuteTaskEventFunction, func)
+
+wxDEFINE_EVENT(wxEVT_LIBBASE_EXECUTE_TASK, WxExecuteTaskEvent);
+
+//
+// WxMessagePumpImpl
+//
+
+class WxMessagePumpImpl : public MessagePump {
+ public:
+  WxMessagePumpImpl(wxEvtHandler* event_handler)
+      : event_handler_(event_handler), is_stopped_(false) {}
+
+  PendingTask GetNextPendingTask(ExecutorId, bool) override {
+    DCHECK(false) << "This method should not be called";
+    return {};
+  }
+
+  bool QueuePendingTask(PendingTask pending_task) override {
+    if (!is_stopped_) {
+      wxPostEvent(event_handler_,
+                  WxExecuteTaskEvent(std::make_shared<MessagePump::PendingTask>(
+                      std::move(pending_task))));
+      return true;
+    }
+    return false;
+  }
+
+  void Stop(PendingTask last_task) override {
+    QueuePendingTask(std::move(last_task));
+    is_stopped_ = true;
+  }
+
+ private:
+  wxEvtHandler* event_handler_;
+  std::atomic_bool is_stopped_;
+};
+
+}  // namespace detail
+
+//
+// WxMessageLoopAttachment
+//
+
+WxMessageLoopAttachment::WxMessageLoopAttachment(wxEvtHandler* event_handler)
+    : event_handler_(event_handler),
+      sequence_id_(base::detail::SequenceIdGenerator::GetNextSequenceId()),
+      message_pump_(
+          std::make_shared<detail::WxMessagePumpImpl>(event_handler_)),
+      task_runner_(SingleThreadTaskRunnerImpl::Create(
+          message_pump_,
+          sequence_id_,
+          0,
+          DelayedTaskManagerSharedInstance::GetOrCreateSharedInstance())),
+      scoped_sequence_id_(sequence_id_),
+      scoped_task_runner_handle_(task_runner_) {
+  DCHECK(event_handler_);
+
+  BindEventHandling();
+}
+
+WxMessageLoopAttachment::~WxMessageLoopAttachment() {
+  UnbindEventHandling();
+  message_pump_->Stop({});
+}
+
+std::shared_ptr<SingleThreadTaskRunner> WxMessageLoopAttachment::TaskRunner()
+    const {
+  return task_runner_;
+}
+
+// static
+void WxMessageLoopAttachment::HandleExecuteTaskEvent(
+    detail::WxExecuteTaskEvent& event) {
+  // We don't have to set scoped sequence id/task runner handle here as this is
+  // handled by the lifetime of owned object.
+  if (event.pending_task_) {
+    std::move(event.pending_task_->task).Run();
+  }
+}
+
+void WxMessageLoopAttachment::BindEventHandling() {
+  event_handler_->Bind(detail::wxEVT_LIBBASE_EXECUTE_TASK,
+                       &WxMessageLoopAttachment::HandleExecuteTaskEvent);
+}
+
+void WxMessageLoopAttachment::UnbindEventHandling() {
+  event_handler_->Unbind(detail::wxEVT_LIBBASE_EXECUTE_TASK,
+                         &WxMessageLoopAttachment::HandleExecuteTaskEvent);
+}
+
+}  // namespace wx
+}  // namespace base

--- a/src/base/message_loop/wx/wx_message_loop_attachment.h
+++ b/src/base/message_loop/wx/wx_message_loop_attachment.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <memory>
+
+#include "base/message_loop/message_pump.h"
+#include "base/sequence_id.h"
+#include "base/single_thread_task_runner.h"
+#include "base/threading/sequenced_task_runner_handle.h"
+
+class wxEvtHandler;
+
+namespace base {
+namespace wx {
+
+namespace detail {
+class WxExecuteTaskEvent;
+}  // namespace detail
+
+class WxMessageLoopAttachment {
+ public:
+  WxMessageLoopAttachment(wxEvtHandler* event_handler);
+  ~WxMessageLoopAttachment();
+
+  std::shared_ptr<SingleThreadTaskRunner> TaskRunner() const;
+
+ private:
+  static void HandleExecuteTaskEvent(detail::WxExecuteTaskEvent& event);
+
+  void BindEventHandling();
+  void UnbindEventHandling();
+
+  wxEvtHandler* event_handler_;
+  SequenceId sequence_id_;
+  std::shared_ptr<MessagePump> message_pump_;
+  std::shared_ptr<SingleThreadTaskRunner> task_runner_;
+  base::detail::ScopedSequenceIdSetter scoped_sequence_id_;
+  SequencedTaskRunnerHandle scoped_task_runner_handle_;
+};
+
+}  // namespace wx
+}  // namespace base

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -47,6 +47,12 @@
           ]
         }
       ]
+    },
+    "wx": {
+      "description": "Build wxWidgets integration module",
+      "dependencies": [
+        "wxwidgets"
+      ]
     }
   },
   "default-features": [


### PR DESCRIPTION
This commit adds implementation of utilities to integrate `libbase` with wxWidgets based applications. Main component available for users is the new class `wxMessageLoopAttachment`, which bridges the wxWidgets event loop with the `libbase` threading/task runner/message loop systems which in turn allows you to - among others - fetching "current's thread's" task runner (even if this is main/wxWidgets thread), posting tasks to it (these will be executed as if you'd post events to specified `wxEventHandler` object) and so on.

Recommended usage is to create an instance of `wxMessageLoopAttachment` when initializing application/wxWidgets thread and destroy it on shutdown. See `wxwidgets_integration` example for more details.