### PR TITLE
[#41] Implement `base::net::UrlRequest` for advanced use cases (streaming)

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -131,9 +131,12 @@ jobs:
       - name: (Optional) Run performance tests
         if: ${{ matrix.run_all }}
         run: ./build/tests/perf/libbase_perf_tests
-      - name: (Optional) Run examples
+      - name: (Optional) Run examples (simple)
         if: ${{ matrix.run_all }}
         run: ./build/examples/simple/simple
+      - name: (Optional) Run examples (networking)
+        if: ${{ matrix.run_all }}
+        run: ./build/examples/networking/networking
 
       # (Optional) Generate code coverage report and upload it
       # - 'gcov'-based is used with CI

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_subdirectory(simple)
 
+if(LIBBASE_BUILD_MODULE_NET)
+  add_subdirectory(networking)
+endif()
+
 if(LIBBASE_BUILD_MODULE_WIN)
   add_subdirectory(winapi_integration)
 endif ()

--- a/examples/networking/CMakeLists.txt
+++ b/examples/networking/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(networking "")
+
+target_compile_options(networking
+  PRIVATE
+    ${LIBBASE_COMPILE_FLAGS}
+)
+
+target_link_libraries(networking
+  PRIVATE
+    libbase
+    libbase_net
+)
+
+target_sources(networking
+  PRIVATE
+    main.cc
+)

--- a/examples/networking/main.cc
+++ b/examples/networking/main.cc
@@ -1,0 +1,147 @@
+#include <thread>
+
+#include "base/bind.h"
+#include "base/callback.h"
+#include "base/init.h"
+#include "base/logging.h"
+#include "base/message_loop/run_loop.h"
+#include "base/net/init.h"
+#include "base/net/simple_url_loader.h"
+#include "base/net/url_request.h"
+#include "base/sequence_checker.h"
+#include "base/timer/elapsed_timer.h"
+
+void LogNetResponse(const base::net::ResourceResponse& response) {
+  LOG(INFO) << "Result: " << static_cast<int>(response.result);
+  LOG(INFO) << "HTTP code: " << response.code;
+  LOG(INFO) << "Final URL: " << response.final_url;
+  LOG(INFO) << "Downloaded " << response.data.size() << " bytes";
+  LOG(INFO) << "Latency: " << response.timing_connect.InMilliseconds() << "ms";
+  LOG(INFO) << "Headers";
+  for (const auto& [h, v] : response.headers) {
+    LOG(INFO) << "  " << h << ": " << v;
+  }
+  LOG_IF(INFO, !response.data.empty())
+      << "Content:\n"
+      << std::string{response.data.begin(), response.data.end()};
+}
+
+void NetExampleGet() {
+  base::RunLoop run_loop{};
+
+  // Try to download and signal on finish
+  base::net::SimpleUrlLoader::DownloadUnbounded(
+      base::net::ResourceRequest{
+          "https://www.google.com/robots.txt",
+          base::net::kDefaultHeaders,
+          base::net::kNoPost,
+          true,
+          base::Seconds(5),
+      },
+      base::BindOnce([](base::net::ResourceResponse response) {
+        LogNetResponse(response);
+      }).Then(run_loop.QuitClosure()));
+
+  // Runs all tasks until the quit callback is called
+  run_loop.Run();
+}
+
+void NetExamplePost() {
+  base::RunLoop run_loop{};
+
+  // Try to download and signal on finish
+  const std::string data_str = "{\"key\": \"value\"}";
+  base::net::SimpleUrlLoader::DownloadUnbounded(
+      base::net::ResourceRequest{
+          "https://httpbin.org/post",
+          {"Content-Type: application/json"},
+          std::vector<uint8_t>{data_str.begin(), data_str.end()},
+          false,
+          base::Seconds(5),
+      },
+      base::BindOnce([](base::net::ResourceResponse response) {
+        LogNetResponse(response);
+      }).Then(run_loop.QuitClosure()));
+
+  run_loop.Run();
+}
+
+class UrlRequestExampleUser : public base::net::UrlRequest::Client {
+ public:
+  UrlRequestExampleUser(base::OnceClosure finished_closure)
+      : finished_closure_(std::move(finished_closure)), request_(this) {}
+
+  void Download(base::net::ResourceRequest request) {
+    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+    request_.Download(std::move(request));
+  }
+
+  void OnResponseStarted(const base::net::UrlRequest* request,
+                         int code,
+                         std::string final_url,
+                         std::map<std::string, std::string> headers) override {
+    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+    DCHECK_EQ(request, &request_);
+
+    LOG(INFO) << __FUNCTION__ << "() code: " << code;
+    LOG(INFO) << __FUNCTION__ << "() final_url: " << final_url;
+    for (const auto& [k, v] : headers) {
+      LOG(INFO) << __FUNCTION__ << "() header[" << k << "]: " << v;
+    }
+  }
+
+  void OnWriteData(const base::net::UrlRequest* request,
+                   std::vector<uint8_t> chunk) override {
+    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+    DCHECK_EQ(request, &request_);
+
+    LOG(INFO) << __FUNCTION__ << "() received bytes: " << chunk.size();
+  }
+
+  void OnRequestFinished(const base::net::UrlRequest* request,
+                         base::net::Result result) override {
+    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+    DCHECK_EQ(request, &request_);
+
+    LOG(INFO) << __FUNCTION__ << "() result: " << static_cast<int>(result);
+    std::move(finished_closure_).Run();
+  }
+
+ private:
+  SEQUENCE_CHECKER(sequence_checker_);
+  base::OnceClosure finished_closure_;
+  base::net::UrlRequest request_;
+};
+
+void NetExampleUrlRequest() {
+  base::RunLoop run_loop;
+
+  UrlRequestExampleUser url_request_user{run_loop.QuitClosure()};
+  url_request_user.Download(base::net::ResourceRequest{
+      "https://www.google.com/robots.txt",
+      base::net::kDefaultHeaders,
+      base::net::kNoPost,
+      false,
+      base::Seconds(5),
+  });
+
+  run_loop.Run();
+}
+
+int main(int argc, char* argv[]) {
+  base::Initialize(argc, argv, base::InitOptions{});
+  base::net::Initialize(base::net::InitOptions{});
+
+  const auto timer = base::ElapsedTimer{};
+
+  NetExampleGet();
+  NetExamplePost();
+  NetExampleUrlRequest();
+
+  LOG(INFO) << "Example finished in " << timer.Elapsed().InMillisecondsF()
+            << "ms";
+
+  base::net::Deinitialize();
+  base::Deinitialize();
+  return 0;
+}

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,12 +1,14 @@
 add_executable(simple "")
 
-target_compile_options(simple PRIVATE ${LIBBASE_COMPILE_FLAGS})
+target_compile_options(simple
+  PRIVATE
+    ${LIBBASE_COMPILE_FLAGS}
+)
 
-if(LIBBASE_BUILD_MODULE_NET)
-  target_link_libraries(simple PRIVATE libbase libbase_net)
-else()
-  target_link_libraries(simple PRIVATE libbase)
-endif()
+target_link_libraries(simple
+  PRIVATE
+    libbase
+)
 
 target_sources(simple
   PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -169,6 +169,8 @@ if(LIBBASE_BUILD_MODULE_NET)
       base/net/result.h
       base/net/simple_url_loader.cc
       base/net/simple_url_loader.h
+      base/net/url_request.cc
+      base/net/url_request.h
   )
 endif()
 

--- a/src/base/net/impl/net_thread.cc
+++ b/src/base/net/impl/net_thread.cc
@@ -47,6 +47,25 @@ RequestCancellationToken NetThread::EnqueueDownload(
   return cancellation_token;
 }
 
+RequestCancellationToken NetThread::EnqueueDownload(
+    ResourceRequest request,
+    std::optional<size_t> max_response_size_bytes,
+    OnceCallback<void(int, std::string, std::map<std::string, std::string>)>
+        on_response_started,
+    RepeatingCallback<void(std::vector<uint8_t>)> on_write_data,
+    OnceCallback<void(Result)> on_finished) {
+  DCHECK(impl_);
+
+  RequestCancellationToken cancellation_token{
+      g_request_id_counter_.fetch_add(1)};
+
+  impl_->EnqueueDownload(std::move(request), std::move(max_response_size_bytes),
+                         cancellation_token, std::move(on_response_started),
+                         std::move(on_write_data), std::move(on_finished));
+
+  return cancellation_token;
+}
+
 void NetThread::CancelRequest(RequestCancellationToken cancellation_token) {
   DCHECK(impl_);
 

--- a/src/base/net/impl/net_thread.h
+++ b/src/base/net/impl/net_thread.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <optional>
+#include <string>
 
 #include "base/callback.h"
 #include "base/net/request_cancellation_token.h"
@@ -22,6 +24,13 @@ class NetThread {
       ResourceRequest request,
       std::optional<size_t> max_response_size_bytes,
       OnceCallback<void(ResourceResponse)> on_done_callback);
+  RequestCancellationToken EnqueueDownload(
+      ResourceRequest request,
+      std::optional<size_t> max_response_size_bytes,
+      OnceCallback<void(int, std::string, std::map<std::string, std::string>)>
+          on_response_started,
+      RepeatingCallback<void(std::vector<uint8_t>)> on_write_data,
+      OnceCallback<void(Result)> on_finished);
 
   void CancelRequest(RequestCancellationToken cancellation_token);
 

--- a/src/base/net/impl/net_thread_impl.h
+++ b/src/base/net/impl/net_thread_impl.h
@@ -28,6 +28,14 @@ class NetThread::NetThreadImpl {
                        std::optional<size_t> max_response_size_bytes,
                        RequestCancellationToken cancellation_token,
                        OnceCallback<void(ResourceResponse)> on_done_callback);
+  void EnqueueDownload(
+      ResourceRequest request,
+      std::optional<size_t> max_response_size_bytes,
+      RequestCancellationToken cancellation_token,
+      OnceCallback<void(int, std::string, std::map<std::string, std::string>)>
+          on_response_started,
+      RepeatingCallback<void(std::vector<uint8_t>)> on_write_data,
+      OnceCallback<void(Result)> on_finished);
 
   void CancelRequest(RequestCancellationToken cancellation_token);
 

--- a/src/base/net/url_request.cc
+++ b/src/base/net/url_request.cc
@@ -1,0 +1,40 @@
+#include "base/net/url_request.h"
+
+#include "base/bind_post_task.h"
+#include "base/net/impl/net_thread.h"
+
+namespace base {
+namespace net {
+
+UrlRequest::UrlRequest(Client* client) : weak_factory_(client) {
+  weak_client_ = weak_factory_.GetWeakPtr();
+}
+
+UrlRequest::~UrlRequest() {
+  Cancel();
+}
+
+void UrlRequest::Download(ResourceRequest request) {
+  DCHECK(weak_client_);
+
+  cancellation_token_ = NetThread::GetInstance().EnqueueDownload(
+      std::move(request), std::nullopt,
+      BindToCurrentSequence(
+          BindOnce(&Client::OnResponseStarted, weak_client_, this), FROM_HERE),
+      BindToCurrentSequence(
+          BindRepeating(&Client::OnWriteData, weak_client_, this), FROM_HERE),
+      BindToCurrentSequence(
+          BindOnce(&Client::OnRequestFinished, weak_client_, this), FROM_HERE));
+}
+
+void UrlRequest::Cancel() {
+  if (!cancellation_token_) {
+    return;
+  }
+
+  NetThread::GetInstance().CancelRequest(std::move(*cancellation_token_));
+  weak_factory_.InvalidateWeakPtrs();
+}
+
+}  // namespace net
+}  // namespace base

--- a/src/base/net/url_request.h
+++ b/src/base/net/url_request.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <map>
+#include <optional>
+#include <string>
+
+#include "base/memory/weak_ptr.h"
+#include "base/net/request_cancellation_token.h"
+#include "base/net/resource_request.h"
+#include "base/net/result.h"
+
+namespace base {
+namespace net {
+
+class UrlRequest {
+ public:
+  class Client {
+   public:
+    virtual void OnResponseStarted(
+        const UrlRequest* request,
+        int code,
+        std::string final_url,
+        std::map<std::string, std::string> headers) = 0;
+    virtual void OnWriteData(const UrlRequest* request,
+                             std::vector<uint8_t> chunk) = 0;
+    virtual void OnRequestFinished(const UrlRequest* request,
+                                   Result result) = 0;
+  };
+
+  UrlRequest(Client* client);
+  ~UrlRequest();
+
+  void Download(ResourceRequest request);
+  void Cancel();
+
+ private:
+  std::optional<RequestCancellationToken> cancellation_token_;
+
+  base::WeakPtr<Client> weak_client_;
+  base::WeakPtrFactory<Client> weak_factory_;
+};
+
+}  // namespace net
+}  // namespace base


### PR DESCRIPTION
This commit adds a new network class `base::net::UrlRequest` that can be used in more advanced scenarios. Contrary to simple url loader usage, here the user receives multiple callbacks on each phase of the request:

- when response starts (with metadata such as result code and headers)
- when new data chunk is fetched (for every downloaded chunk)
- when request finishes (either succesfully or not)

Only the last call is guaranteed to be performed, so users should not depend on receiving `OnResponseStarted` or `OnWriteData` calls in their applications.

Users are required to buffer the data by themselves and cancel the requests when needed. Once `UrlRequest::Cancel` method is invoked (or the `UrlRequest` object is destroyed), it is guaranteed that no more calls to passed `UrlRequest::Client` will be made (not even `OnRequestFinished`) and the request will be asynchronously cancelled at first chance.

Additionally, new example called `networking` was added and earlier additions to `simple` example related to networking module were moved to it along with new example that showcases usage of `UrlRequest` class.