### PR TITLE
[#47](#48) Revert temporary workaround to pin CMake to v3.36.x as its not needed anymore

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,12 +41,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Temporarily ping CMake version to 3.31 (see #47)
-      - name: Install cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '3.31.x'
-
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,7 +45,6 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg
-          vcpkgGitCommitId: 'ce613c41372b23b1f51333815feb3edd87ef8a8b'
 
       - name: CMake configuration
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_args }} -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,7 +45,7 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg
-          vcpkgGitCommitId: '782ccc18d8b819cdef6794a6c03eb3d9f7cd04aa'
+          vcpkgGitCommitId: 'ce613c41372b23b1f51333815feb3edd87ef8a8b'
 
       - name: CMake configuration
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_args }} -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,7 +29,7 @@ jobs:
           # Optional module builds
           - os: macos-latest
             build_type: Release
-            name_suffix: "(wxWidget integration)"
+            name_suffix: "(wxWidgets integration)"
             compiler: {name: Clang, cc: clang, cxx: clang++}
             cmake_args: "-DLIBBASE_BUILD_MODULE_WX=ON"
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -84,12 +84,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Temporarily ping CMake version to 3.31 (see #47)
-      - name: Install cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '3.31.x'
-
       # Setup vcpkg
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -50,7 +50,7 @@ jobs:
         ]
         include:
           # Optional module builds
-          - os_compiler: {os: ubuntu-24.04, name: Clang 18 (wxWidget integration), cc: clang-18, cxx: clang++-18, tidy: clang-tidy-18 }
+          - os_compiler: {os: ubuntu-24.04, name: Clang 18 (wxWidgets integration), cc: clang-18, cxx: clang++-18, tidy: clang-tidy-18 }
             build_type: Release
             cmake_args: "-DLIBBASE_BUILD_MODULE_WX=ON"
             package_deps: "autoconf automake libtool pkg-config libx11-dev libxft-dev libxext-dev libxi-dev libxtst-dev libltdl-dev bison gperf libxinerama-dev libxdamage-dev libxcursor-dev libxi-dev libxrandr-dev libgles2-mesa-dev"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -89,7 +89,7 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg
-          vcpkgGitCommitId: '782ccc18d8b819cdef6794a6c03eb3d9f7cd04aa'
+          vcpkgGitCommitId: 'ce613c41372b23b1f51333815feb3edd87ef8a8b'
 
       # (Optional) Ensure required software is installed
       - name: (Optional) Compiler instalation

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -89,7 +89,6 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg
-          vcpkgGitCommitId: 'ce613c41372b23b1f51333815feb3edd87ef8a8b'
 
       # (Optional) Ensure required software is installed
       - name: (Optional) Compiler instalation

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
           # Optional module builds
           - os: windows-latest
             build_type: Release
-            name_suffix: "(wxWidget integration)"
+            name_suffix: "(wxWidgets integration)"
             cmake_args: "-DLIBBASE_BUILD_MODULE_WX=ON"
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,12 +33,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Temporarily ping CMake version to 3.31 (see #47)
-      - name: Install cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '3.31.x'
-
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,7 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg
-          vcpkgGitCommitId: '782ccc18d8b819cdef6794a6c03eb3d9f7cd04aa'
+          vcpkgGitCommitId: 'ce613c41372b23b1f51333815feb3edd87ef8a8b'
 
       - name: CMake configuration
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_args }} -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,6 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg
-          vcpkgGitCommitId: 'ce613c41372b23b1f51333815feb3edd87ef8a8b'
 
       - name: CMake configuration
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_args }} -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "782ccc18d8b819cdef6794a6c03eb3d9f7cd04aa",
+    "baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
This reverts commit 754c3316497db08e85a0d68851ecaa62daa0b38a.

The original commit was a temporary workaround for a breaking change in GitHub Action's where workers started using CMake 4.0.0 which had a breaking changes from 3.x versions and libraries were not ready for it yet.

Let's also update vcpkg baseline commit which could have updated packages to work with newer CMake.