### PR TITLE
Add module ifdef guards and helper methods to net::ResourceRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ For more details with examples see the
 [documentation](https://ripper37.github.io/libbase/).
 
 
-### Building `libbase`
+## Building `libbase`
 
-#### Dependencies
+### Dependencies
 
 - [GLOG](https://github.com/google/glog)
 - (Optional) [libcurl](https://curl.se/libcurl/) - for networking module
@@ -33,7 +33,7 @@ Dependencies either have to be already installed and CMake has to be able to
 find them with `find_package()` or they can be resolved with `vcpkg`
 (recommended).
 
-#### Build with pre-existing `vcpkg` installation
+### Build with pre-existing `vcpkg` installation
 
 ```bash
 export VCPKG_ROOT=/path/to/vcpkg/
@@ -48,7 +48,7 @@ cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/v
 cmake --build build [-j <parallel_jobs>] [--config <Release|Debug>]
 ```
 
-#### Build with internal `vcpkg` installation
+### Build with internal `vcpkg` installation
 
 If you don't have (or don't want to use) pre-existing `vcpkg` installation you
 can ask `libbase` to set up its own internal `vcpkg` installation and use it
@@ -59,7 +59,7 @@ cmake -S . -B build -DLIBBASE_AUTO_VCPKG=1
 cmake --build build [-j <parallel_jobs>] [--config <Release|Debug>]
 ```
 
-#### Build with Conan
+### Build with Conan
 
 ```bash
 conan install . --build=missing -s build_type=Release [-o '&:option=value']
@@ -70,7 +70,7 @@ cmake --build --preset conan-release [-j <parallel_jobs>]
 See `options` and `default_options` attributes in `conanfile.py` for available
 build options.
 
-#### Build manually
+### Build manually
 
 You can also manually build and install all required dependencies and then
 simply build `libbase` with:
@@ -80,7 +80,7 @@ cmake -S . -B build
 cmake --build build [-j <parallel_jobs>] [--config <Release|Debug>]
 ```
 
-#### Running unit tests
+### Running unit tests
 
 Once you've built `libbase` you can run tests with:
 
@@ -92,13 +92,13 @@ For more details please refer to the
 [building documentation](https://ripper37.github.io/libbase/master/getting_started/building.html).
 
 
-### Using `libbase` in your project
+## Using `libbase` in your project
 
 You can install `libbase` in multiple ways - either by manually building it or
 using a package manager like `vcpkg` (recommended) to do it for you. Once you've
 installed it, you will need to find and link with it.
 
-#### Install with `vcpkg`
+### Install with `vcpkg`
 
 To install `libbase` with `vcpkg` in the
 [_manifest mode_](https://learn.microsoft.com/en-us/vcpkg/concepts/manifest-mode#manifest-files-in-projects)
@@ -124,7 +124,7 @@ in your terminal:
 vcpkg install ripper37-libbase
 ```
 
-#### Import into your CMake project with FetchContent
+### Import into your CMake project with FetchContent
 
 If you prefer to manually import your dependencies with CMake's `FetchContent`
 you can import `libbase` in your project by adding this to your `CMakeFiles.txt`
@@ -147,7 +147,7 @@ FetchContent_MakeAvailable(libbase)
 > `FetchContent` as well.
 
 
-#### Manual
+### Manual
 
 Lastly you can simply build and install `libbase` manually. Please refer to the
 [building section above](https://github.com/RippeR37/libbase?tab=readme-ov-file#building-libbase)
@@ -158,7 +158,7 @@ them all with:
 cmake --install build_directory [--prefix <install_path_prefix>]
 ```
 
-#### Add to your CMake project
+### Add to your CMake project
 
 Once you've installed `libbase` in your system, simply ask CMake to find it and
 link all with:
@@ -202,6 +202,6 @@ or check out the example projects:
 * Clang (13 through 18)
 * MSVC (2022 19.43)
 
-### License
+## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/docs/features/networking.rst
+++ b/docs/features/networking.rst
@@ -84,9 +84,10 @@ function to **asynchronously** cancel related request.
 
       void PerformRequest(std::string resource_url) {
         base::net::SimpleUrlLoader::DownloadUnbounded(
-            base::net::ResourceRequest{resource_url},
+            base::net::ResourceRequest{resource_url}.WithTimeout(base::Seconds(5)),
             base::BindOnce(&OnResponse));
       }
+
       void OnResponse(base::net::ResourceResponse response) {
         // Check response status and other metadata
       }

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 if(LIBBASE_BUILD_MODULE_WIN)
   add_subdirectory(winapi_integration)
-endif ()
+endif()
 
 if(LIBBASE_BUILD_MODULE_WX)
   add_subdirectory(wxwidgets_integration)

--- a/examples/networking/main.cc
+++ b/examples/networking/main.cc
@@ -31,13 +31,9 @@ void NetExampleGet() {
 
   // Try to download and signal on finish
   base::net::SimpleUrlLoader::DownloadUnbounded(
-      base::net::ResourceRequest{
-          "https://www.google.com/robots.txt",
-          base::net::kDefaultHeaders,
-          base::net::kNoPost,
-          true,
-          base::Seconds(5),
-      },
+      base::net::ResourceRequest{"https://www.google.com/robots.txt"}
+          .WithHeadersOnly()
+          .WithTimeout(base::Seconds(5)),
       base::BindOnce([](base::net::ResourceResponse response) {
         LogNetResponse(response);
       }).Then(run_loop.QuitClosure()));
@@ -50,15 +46,11 @@ void NetExamplePost() {
   base::RunLoop run_loop{};
 
   // Try to download and signal on finish
-  const std::string data_str = "{\"key\": \"value\"}";
   base::net::SimpleUrlLoader::DownloadUnbounded(
-      base::net::ResourceRequest{
-          "https://httpbin.org/post",
-          {"Content-Type: application/json"},
-          std::vector<uint8_t>{data_str.begin(), data_str.end()},
-          false,
-          base::Seconds(5),
-      },
+      base::net::ResourceRequest{"https://httpbin.org/post"}
+          .WithHeaders({"Content-Type: application/json"})
+          .WithPostData("{\"key\": \"value\"}")
+          .WithTimeout(base::Seconds(5)),
       base::BindOnce([](base::net::ResourceResponse response) {
         LogNetResponse(response);
       }).Then(run_loop.QuitClosure()));
@@ -117,13 +109,9 @@ void NetExampleUrlRequest() {
   base::RunLoop run_loop;
 
   UrlRequestExampleUser url_request_user{run_loop.QuitClosure()};
-  url_request_user.Download(base::net::ResourceRequest{
-      "https://www.google.com/robots.txt",
-      base::net::kDefaultHeaders,
-      base::net::kNoPost,
-      false,
-      base::Seconds(5),
-  });
+  url_request_user.Download(
+      base::net::ResourceRequest{"https://www.google.com/robots.txt"}
+          .WithTimeout(base::Seconds(5)));
 
   run_loop.Run();
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,7 +137,6 @@ if(LIBBASE_BUILD_MODULE_NET)
   target_compile_definitions(libbase_net
     PUBLIC
       ${LIBBASE_FEATURE_DEFINES}
-    INTERFACE
       LIBBASE_MODULE_NET
   )
 
@@ -163,6 +162,7 @@ if(LIBBASE_BUILD_MODULE_NET)
       base/net/init.h
       base/net/request_cancellation_token.cc
       base/net/request_cancellation_token.h
+      base/net/resource_request.cc
       base/net/resource_request.h
       base/net/resource_response.h
       base/net/result.h
@@ -188,7 +188,6 @@ if(LIBBASE_BUILD_MODULE_WIN)
   target_compile_definitions(libbase_win
     PUBLIC
       ${LIBBASE_FEATURE_DEFINES}
-    INTERFACE
       LIBBASE_MODULE_WIN
   )
 
@@ -228,7 +227,6 @@ if(LIBBASE_BUILD_MODULE_WX)
   target_compile_definitions(libbase_wx
     PUBLIC
       ${LIBBASE_FEATURE_DEFINES}
-    INTERFACE
       LIBBASE_MODULE_WX
   )
 

--- a/src/base/message_loop/win/win_message_loop_attachment.h
+++ b/src/base/message_loop/win/win_message_loop_attachment.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #if defined(LIBBASE_IS_WINDOWS)
+#if defined(LIBBASE_MODULE_WIN)
 
 #include <memory>
 
@@ -42,4 +43,5 @@ class WinMessageLoopAttachment {
 }  // namespace win
 }  // namespace base
 
+#endif  // defined(LIBBASE_MODULE_WIN)
 #endif  // defined(LIBBASE_IS_WINDOWS)

--- a/src/base/message_loop/wx/wx_message_loop_attachment.h
+++ b/src/base/message_loop/wx/wx_message_loop_attachment.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(LIBBASE_MODULE_WX)
+
 #include <memory>
 
 #include "base/message_loop/message_pump.h"
@@ -39,3 +41,5 @@ class WxMessageLoopAttachment {
 
 }  // namespace wx
 }  // namespace base
+
+#endif  // defined(LIBBASE_MODULE_WX)

--- a/src/base/net/impl/net_thread.h
+++ b/src/base/net/impl/net_thread.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(LIBBASE_MODULE_NET)
+
 #include <map>
 #include <memory>
 #include <optional>
@@ -42,3 +44,5 @@ class NetThread {
 
 }  // namespace net
 }  // namespace base
+
+#endif  // defined(LIBBASE_MODULE_NET)

--- a/src/base/net/impl/net_thread_impl.h
+++ b/src/base/net/impl/net_thread_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(LIBBASE_MODULE_NET)
+
 #include <atomic>
 #include <map>
 #include <mutex>
@@ -78,3 +80,5 @@ class NetThread::NetThreadImpl {
 
 }  // namespace net
 }  // namespace base
+
+#endif  // defined(LIBBASE_MODULE_NET)

--- a/src/base/net/init.h
+++ b/src/base/net/init.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(LIBBASE_MODULE_NET)
+
 namespace base {
 namespace net {
 
@@ -10,3 +12,5 @@ void Deinitialize();
 
 }  // namespace net
 }  // namespace base
+
+#endif  // defined(LIBBASE_MODULE_NET)

--- a/src/base/net/request_cancellation_token.h
+++ b/src/base/net/request_cancellation_token.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(LIBBASE_MODULE_NET)
+
 #include <cstddef>
 
 namespace base {
@@ -16,3 +18,5 @@ struct RequestCancellationToken {
 
 }  // namespace net
 }  // namespace base
+
+#endif  // defined(LIBBASE_MODULE_NET)

--- a/src/base/net/resource_request.cc
+++ b/src/base/net/resource_request.cc
@@ -1,0 +1,83 @@
+#include "base/net/resource_request.h"
+
+namespace base {
+namespace net {
+
+ResourceRequest ResourceRequest::WithHeaders(
+    std::vector<std::string> new_headers) const& {
+  return ResourceRequest{*this}.WithHeaders(std::move(new_headers));
+}
+
+ResourceRequest&& ResourceRequest::WithHeaders(
+    std::vector<std::string> new_headers) && {
+  headers = std::move(new_headers);
+  return std::move(*this);
+}
+
+ResourceRequest ResourceRequest::WithPostData(
+    std::vector<uint8_t> new_post_data) const& {
+  return ResourceRequest{*this}.WithPostData(std::move(new_post_data));
+}
+
+ResourceRequest&& ResourceRequest::WithPostData(
+    std::vector<uint8_t> new_post_data) && {
+  post_data = std::move(new_post_data);
+  return std::move(*this);
+}
+
+ResourceRequest ResourceRequest::WithPostData(
+    std::string_view new_post_data) const& {
+  return ResourceRequest{*this}.WithPostData(std::move(new_post_data));
+}
+
+ResourceRequest&& ResourceRequest::WithPostData(
+    std::string_view new_post_data) && {
+  post_data = std::vector<uint8_t>(new_post_data.begin(), new_post_data.end());
+  return std::move(*this);
+}
+
+ResourceRequest ResourceRequest::WithHeadersOnly(bool new_headers_only) const& {
+  return ResourceRequest{*this}.WithHeadersOnly(std::move(new_headers_only));
+}
+
+ResourceRequest&& ResourceRequest::WithHeadersOnly(bool new_headers_only) && {
+  headers_only = std::move(new_headers_only);
+  return std::move(*this);
+}
+
+ResourceRequest ResourceRequest::WithTimeout(
+    base::TimeDelta new_timeout) const& {
+  return ResourceRequest{*this}.WithTimeout(std::move(new_timeout));
+}
+
+ResourceRequest&& ResourceRequest::WithTimeout(base::TimeDelta new_timeout) && {
+  timeout = std::move(new_timeout);
+  return std::move(*this);
+}
+
+ResourceRequest ResourceRequest::WithConnectTimeout(
+    base::TimeDelta new_connect_timeout) const& {
+  return ResourceRequest{*this}.WithConnectTimeout(
+      std::move(new_connect_timeout));
+}
+
+ResourceRequest&& ResourceRequest::WithConnectTimeout(
+    base::TimeDelta new_connect_timeout) && {
+  connect_timeout = std::move(new_connect_timeout);
+  return std::move(*this);
+}
+
+ResourceRequest ResourceRequest::WithFollowRedirects(
+    bool new_follow_redirects) const& {
+  return ResourceRequest{*this}.WithFollowRedirects(
+      std::move(new_follow_redirects));
+}
+
+ResourceRequest&& ResourceRequest::WithFollowRedirects(
+    bool new_follow_redirects) && {
+  follow_redirects = std::move(new_follow_redirects);
+  return std::move(*this);
+}
+
+}  // namespace net
+}  // namespace base

--- a/src/base/net/resource_request.h
+++ b/src/base/net/resource_request.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#if defined(LIBBASE_MODULE_NET)
+
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/time/time_delta.h"
@@ -11,19 +14,44 @@ namespace base {
 namespace net {
 
 const auto kDefaultHeaders = std::vector<std::string>{};
+const auto kNoPostData = std::optional<std::vector<uint8_t>>{};
 const auto kNoPost = std::nullopt;
 const auto kNoTimeout = base::TimeDelta{};
 
 struct ResourceRequest {
   std::string url;
   std::vector<std::string> headers = kDefaultHeaders;
-  std::optional<std::vector<uint8_t>> post_data;
+  std::optional<std::vector<uint8_t>> post_data = kNoPostData;
   bool headers_only = false;
 
   base::TimeDelta timeout = kNoTimeout;
   base::TimeDelta connect_timeout = kNoTimeout;
   bool follow_redirects = true;
+
+  ResourceRequest WithHeaders(std::vector<std::string> new_headers) const&;
+  ResourceRequest&& WithHeaders(std::vector<std::string> new_headers) &&;
+
+  ResourceRequest WithPostData(std::vector<uint8_t> new_post_data) const&;
+  ResourceRequest&& WithPostData(std::vector<uint8_t> new_post_data) &&;
+
+  ResourceRequest WithPostData(std::string_view new_post_data) const&;
+  ResourceRequest&& WithPostData(std::string_view new_post_data) &&;
+
+  ResourceRequest WithHeadersOnly(bool new_headers_only = true) const&;
+  ResourceRequest&& WithHeadersOnly(bool new_headers_only = true) &&;
+
+  ResourceRequest WithTimeout(base::TimeDelta new_timeout) const&;
+  ResourceRequest&& WithTimeout(base::TimeDelta new_timeout) &&;
+
+  ResourceRequest WithConnectTimeout(
+      base::TimeDelta new_connect_timeout) const&;
+  ResourceRequest&& WithConnectTimeout(base::TimeDelta new_connect_timeout) &&;
+
+  ResourceRequest WithFollowRedirects(bool new_follow_redirects = true) const&;
+  ResourceRequest&& WithFollowRedirects(bool new_follow_redirects = true) &&;
 };
 
 }  // namespace net
 }  // namespace base
+
+#endif  // defined(LIBBASE_MODULE_NET)

--- a/src/base/net/resource_response.h
+++ b/src/base/net/resource_response.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(LIBBASE_MODULE_NET)
+
 #include <cstdint>
 #include <map>
 #include <string>
@@ -26,3 +28,5 @@ struct ResourceResponse {
 
 }  // namespace net
 }  // namespace base
+
+#endif  // defined(LIBBASE_MODULE_NET)

--- a/src/base/net/result.h
+++ b/src/base/net/result.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(LIBBASE_MODULE_NET)
+
 namespace base {
 namespace net {
 
@@ -19,3 +21,5 @@ enum class Result {
 
 }  // namespace net
 }  // namespace base
+
+#endif  // defined(LIBBASE_MODULE_NET)

--- a/src/base/net/simple_url_loader.h
+++ b/src/base/net/simple_url_loader.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(LIBBASE_MODULE_NET)
+
 #include "base/callback.h"
 #include "base/net/request_cancellation_token.h"
 #include "base/net/resource_request.h"
@@ -28,3 +30,5 @@ class SimpleUrlLoader {
 
 }  // namespace net
 }  // namespace base
+
+#endif  // defined(LIBBASE_MODULE_NET)

--- a/src/base/net/url_request.h
+++ b/src/base/net/url_request.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(LIBBASE_MODULE_NET)
+
 #include <map>
 #include <optional>
 #include <string>
@@ -48,3 +50,5 @@ class UrlRequest {
 
 }  // namespace net
 }  // namespace base
+
+#endif  // defined(LIBBASE_MODULE_NET)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -17,10 +17,21 @@ target_compile_options(libbase_unittests PRIVATE "${LIBBASE_COMPILE_FLAGS}")
 target_include_directories(libbase_unittests PRIVATE
   ${PROJECT_SOURCE_DIR}/tests/unit/mock/)
 
-target_link_libraries(libbase_unittests PRIVATE
-  libbase
-  GTest::gtest
-  GTest::gmock)
+target_link_libraries(libbase_unittests
+  PRIVATE
+    libbase
+    GTest::gtest
+    GTest::gmock
+)
+
+# optionally link with libbase_net for networking module tests
+# these tests will be enabled if LIBBASE_MODULE_NET is defined
+if(TARGET libbase::libbase_net)
+  target_link_libraries(libbase_unittests
+    PRIVATE
+      libbase::libbase_net
+  )
+endif()
 
 target_sources(libbase_unittests
   PRIVATE
@@ -34,6 +45,7 @@ target_sources(libbase_unittests
     base/message_loop/message_loop_impl_unittests.cc
     base/message_loop/message_pump_impl_unittests.cc
     base/message_loop/run_loop_unittests.cc
+    base/net/resource_request_unittests.cc
     base/sequenced_task_runner_helpers_unittest.cc
     base/sequenced_task_runner_unittests.cc
     base/synchronization/auto_signaller_unittests.cc

--- a/tests/unit/base/net/resource_request_unittests.cc
+++ b/tests/unit/base/net/resource_request_unittests.cc
@@ -1,0 +1,137 @@
+#if defined(LIBBASE_MODULE_NET)
+
+#include "base/net/resource_request.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace {
+const std::string kTestUrl = "http://example.com";
+const std::string kTestHeader1 = "Key1: Value1";
+const std::string kTestHeader2 = "Key2: Value2";
+const std::vector<uint8_t> kTestPostData1 = {'T', 'e', 's', 't', '1'};
+const std::vector<uint8_t> kTestPostData2 = {'T', 'e', 's', 't', '2'};
+const std::string kTestPostDataStr1 = "Test1";
+const std::string kTestPostDataStr2 = "Test2";
+}  // namespace
+
+base::net::ResourceRequest GetBaseRequest() {
+  return base::net::ResourceRequest{kTestUrl};
+}
+
+TEST(NET_ResourceRequest, SimpleWithLvalue) {
+  {
+    auto req = GetBaseRequest();
+    auto&& req2 = req.WithHeaders({kTestHeader1});
+
+    EXPECT_TRUE(req.headers.empty());
+    EXPECT_EQ(req2.headers.size(), 1u);
+    EXPECT_EQ(req2.headers[0], kTestHeader1);
+  }
+
+  {
+    auto req = GetBaseRequest();
+    auto&& req2 = req.WithPostData(kTestPostData1);
+
+    EXPECT_TRUE(!req.post_data);
+    ASSERT_TRUE(req2.post_data);
+    EXPECT_EQ(*req2.post_data, kTestPostData1);
+  }
+
+  {
+    auto req = GetBaseRequest();
+    auto&& req2 = req.WithPostData(kTestPostDataStr1);
+
+    EXPECT_TRUE(!req.post_data);
+    ASSERT_TRUE(req2.post_data);
+    EXPECT_EQ(*req2.post_data, kTestPostData1);
+  }
+
+  {
+    auto req = GetBaseRequest();
+    const bool org_value = req.headers_only;
+    auto&& req2 = req.WithHeadersOnly(!org_value);
+
+    EXPECT_EQ(req.headers_only, org_value);
+    EXPECT_EQ(req2.headers_only, !org_value);
+  }
+
+  {
+    auto req = GetBaseRequest();
+    auto&& req2 = req.WithTimeout(base::Seconds(10));
+
+    EXPECT_TRUE(req.timeout.IsZero());
+    EXPECT_EQ(req2.timeout, base::Seconds(10));
+  }
+
+  {
+    auto req = GetBaseRequest();
+    auto&& req2 = req.WithConnectTimeout(base::Seconds(20));
+
+    EXPECT_TRUE(req.connect_timeout.IsZero());
+    EXPECT_EQ(req2.connect_timeout, base::Seconds(20));
+  }
+
+  {
+    auto req = GetBaseRequest();
+    const bool org_value = req.follow_redirects;
+    auto&& req2 = req.WithFollowRedirects(!org_value);
+
+    EXPECT_EQ(req.follow_redirects, org_value);
+    EXPECT_EQ(req2.follow_redirects, !org_value);
+  }
+}
+
+TEST(NET_ResourceRequest, SimpleWithRvalue) {
+  {
+    auto req = GetBaseRequest().WithHeaders({kTestHeader1});
+
+    ASSERT_EQ(req.headers.size(), 1u);
+    EXPECT_EQ(req.headers[0], kTestHeader1);
+  }
+
+  {
+    auto req = GetBaseRequest().WithPostData(kTestPostData1);
+    ;
+
+    ASSERT_TRUE(req.post_data);
+    EXPECT_EQ(*req.post_data, kTestPostData1);
+  }
+
+  {
+    auto req = GetBaseRequest().WithPostData(kTestPostDataStr1);
+
+    ASSERT_TRUE(req.post_data);
+    EXPECT_EQ(*req.post_data, kTestPostData1);
+  }
+
+  {
+    auto req = GetBaseRequest();
+    auto req2 = GetBaseRequest().WithHeadersOnly(!req.headers_only);
+
+    EXPECT_NE(req.headers_only, req2.headers_only);
+  }
+
+  {
+    auto req = GetBaseRequest().WithTimeout(base::Seconds(10));
+    ;
+
+    EXPECT_EQ(req.timeout, base::Seconds(10));
+  }
+
+  {
+    auto req = GetBaseRequest().WithConnectTimeout(base::Seconds(20));
+
+    EXPECT_EQ(req.connect_timeout, base::Seconds(20));
+  }
+
+  {
+    auto req = GetBaseRequest();
+    auto req2 = GetBaseRequest().WithFollowRedirects(!req.follow_redirects);
+
+    EXPECT_NE(req.follow_redirects, req2.follow_redirects);
+  }
+}
+
+#endif  // defined(LIBBASE_MODULE_NET)


### PR DESCRIPTION
This commit adds #ifdef guards to all headers that are for optional modules to ensure that code in them is not processed if the module is not built/installed. At the moment there are no errors, but this may change in the future.

Furthermore, this commit also adds some convenience helper methods to `base::net::ResourceRequest` to make it easier to create them. Previously user had to provide all parameters until the last intended one (due no designed initializers in C++17). With new methods, users can start with URL and then add parameters as they see fit. Example:

```cpp
    base::net::ResourceRequest{"https://www.google.com/robots.txt"}
        .WithHeadersOnly()
        .WithTimeout(base::Seconds(5)),
```