### PR TITLE
Fix compilation on MSVC 2019

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-latest]
+        os: [windows-2019, windows-2022, windows-latest]
         build_type: [Release, Debug]
         name_suffix: [""]
         cmake_args: [""]

--- a/cmake/SetupCompileFlags.cmake
+++ b/cmake/SetupCompileFlags.cmake
@@ -30,7 +30,7 @@ function(SETUP_COMPILE_FLAGS)
         endif()
       endif()
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-      set(WARNINGS "/W4;/WX;/EHsc;/permissive-")
+      set(WARNINGS "/W4;/WX;/EHsc;/permissive-;/W34996;/W4244")
   endif()
 
   if(LIBBASE_BUILD_TESTS AND LIBBASE_CODE_COVERAGE)


### PR DESCRIPTION
This commit fixes the compilation on older MSVC 2019 (19.29) by converting two
warnings that were treated as errors back to warnings. This problems doesn't occur
on newer MSVC 2022 and probably is resolved on glog's `master` or in one of the
maintained forks (`ng-log` or Abseil Logging).

For `v1.2.0` we should probably update/change the dependency to one of those
to stay with maintained dependencies.