### PR TITLE
Add new CI job to verify version in files match Git tag name

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -165,3 +165,27 @@ jobs:
           path: install
           retention-days: 7
         continue-on-error: true
+
+  # Verify release (tag push)
+  release-tests:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Verify versions
+      run: |
+        TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+        CMAKE_VERSION=$(tr -d '\n' < CMakeLists.txt | grep -oP 'project\([^()]*VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+        VCPKG_VERSION=$(jq -r '.version' vcpkg.json)
+
+        if [[ "$TAG_VERSION" != "$CMAKE_VERSION" ]]; then
+          echo "::error::Git tag version ($TAG_VERSION) does not match CMakeLists.txt version ($CMAKE_VERSION)"
+          EXIT_CODE=1
+        fi
+        if [[ "$TAG_VERSION" != "$VCPKG_VERSION" ]]; then
+          echo "::error::Git tag version ($TAG_VERSION) does not match vcpkg.json version ($VCPKG_VERSION)"
+          EXIT_CODE=1
+        fi
+        exit $EXIT_CODE


### PR DESCRIPTION
This commit adds a new job to the GitHub Actions workflow that verifies that the version specified in the CMakeLists.txt and vcpkg.json files matches the version from Git tag name. It will run only when a tag is pushed.