### PR TITLE
Update GitHub CI workflows (minor issues)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -63,7 +63,7 @@ jobs:
         if: matrix.compiler.package && github.event_name != 'pull_request' && success()
         uses: actions/upload-artifact@v4
         with:
-          name: libbase-${{ github.ref_name }}-${{ matrix.compiler.cc }}-${{ matrix.build_type }}-${{ matrix.os }}-x64.zip
+          name: libbase-${{ github.ref_name }}-${{ matrix.compiler.cc }}-${{ matrix.build_type }}-${{ matrix.os }}.zip
           path: install
           retention-days: 7
         continue-on-error: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, windows-latest]
+        os: [windows-2022, windows-latest]
         build_type: [Release, Debug]
         name_suffix: [""]
         cmake_args: [""]


### PR DESCRIPTION
Remove misleading `x64` suffix from macOS packages as macOS 14 and 15 are on ARM and not x64.
Also remove windows-2019 runs as its not supported anymore.