### PR TITLE
[Networking] Return error on HTTP 4xx and 5xx responses + utils

### DIFF
--- a/examples/networking/main.cc
+++ b/examples/networking/main.cc
@@ -21,9 +21,8 @@ void LogNetResponse(const base::net::ResourceResponse& response) {
   for (const auto& [h, v] : response.headers) {
     LOG(INFO) << "  " << h << ": " << v;
   }
-  LOG_IF(INFO, !response.data.empty())
-      << "Content:\n"
-      << std::string{response.data.begin(), response.data.end()};
+  LOG_IF(INFO, !response.data.empty()) << "Content:\n"
+                                       << response.DataAsStringView();
 }
 
 void NetExampleGet() {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,6 +164,7 @@ if(LIBBASE_BUILD_MODULE_NET)
       base/net/request_cancellation_token.h
       base/net/resource_request.cc
       base/net/resource_request.h
+      base/net/resource_response.cc
       base/net/resource_response.h
       base/net/result.h
       base/net/simple_url_loader.cc

--- a/src/base/net/resource_response.cc
+++ b/src/base/net/resource_response.cc
@@ -1,0 +1,15 @@
+#include "base/net/resource_response.h"
+
+namespace base {
+namespace net {
+
+std::string ResourceResponse::DataAsString() const {
+  return std::string{data.begin(), data.end()};
+}
+
+std::string_view ResourceResponse::DataAsStringView() const {
+  return std::string_view{reinterpret_cast<const char*>(data.data()), data.size()};
+}
+
+}  // namespace net
+}  // namespace base

--- a/src/base/net/resource_response.cc
+++ b/src/base/net/resource_response.cc
@@ -8,7 +8,8 @@ std::string ResourceResponse::DataAsString() const {
 }
 
 std::string_view ResourceResponse::DataAsStringView() const {
-  return std::string_view{reinterpret_cast<const char*>(data.data()), data.size()};
+  return std::string_view{reinterpret_cast<const char*>(data.data()),
+                          data.size()};
 }
 
 }  // namespace net

--- a/src/base/net/resource_response.h
+++ b/src/base/net/resource_response.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/net/result.h"
@@ -24,6 +25,9 @@ struct ResourceResponse {
   base::TimeDelta timing_connect = base::Seconds(-1);
   base::TimeDelta timing_start_transfer = base::Seconds(-1);
   base::TimeDelta timing_total = base::Seconds(-1);
+
+  std::string DataAsString() const;
+  std::string_view DataAsStringView() const;
 };
 
 }  // namespace net


### PR DESCRIPTION
This is a bug fix that is also a breaking change. Network requests that
technically succeeded in being performed but resulted in HTTP error
codes (4xx or 5xx) used to be returned as non-errors (`Result::kOk`).
With this change, such responses will be returned with an error status
(`Result::kError`) instead to simplify error handling for library users.

Additionally, a new helper functions were added to `ResourceResponse`
class:

* `base::net::ResourceResponse::DataAsString()`
  * creates a copy of the response data in `std::string` object
* `base::net::ResourceResponse::DataAsStringView()`
  * creates a non-owning view of the response data in `std::string_view` 
    object

These should also make it simpler to use response data by library users.